### PR TITLE
Collect contents of /var/lib/docker/containers and some minor cosmetic changes to printout on execution.

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -418,7 +418,7 @@ get_containers_logs()
   try "collect containers logs"
   dstdir="${info_system}/containers_logs"
   mkdir -p ${dstdir}
-  cp -R /var/lib/docker/containers ${dstdir}
+  cp -fR /var/lib/docker/containers ${dstdir}
 }
 
 enable_docker_debug()

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -159,6 +159,7 @@ collect_brief() {
   get_docker_info
   get_ecs_logs
   get_containers_info
+  get_containers_logs
   get_docker_logs
 }
 
@@ -410,6 +411,14 @@ get_containers_info()
   else
     die "ecs-agent not running.."
   fi
+}
+
+get_containers_logs()
+{
+  try "collect containers logs"
+  dstdir="${info_system}/containers_logs"
+  mkdir -p ${dstdir}
+  cp /var/lib/docker/containers ${dstdir}
 }
 
 enable_docker_debug()

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -302,6 +302,7 @@ get_docker_logs()
       ;;
   esac
 
+  ok
 }
 
 get_ecs_logs()

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -418,7 +418,10 @@ get_containers_logs()
   try "collect containers logs"
   dstdir="${info_system}/containers_logs"
   mkdir -p ${dstdir}
+
   cp -fR /var/lib/docker/containers ${dstdir}
+
+  ok
 }
 
 enable_docker_debug()

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -418,7 +418,7 @@ get_containers_logs()
   try "collect containers logs"
   dstdir="${info_system}/containers_logs"
   mkdir -p ${dstdir}
-  cp /var/lib/docker/containers ${dstdir}
+  cp -R /var/lib/docker/containers ${dstdir}
 }
 
 enable_docker_debug()


### PR DESCRIPTION
Collect the contents of the /var/lib/docker/containers for additional information regarding the currently RUNNING and previous containers executed on the Instance.
Useful in case we need container stdout or stderr output of containers and when user does not have task logging enabled.

Added an OK to the printout of the workflow after the "Trying to collect docker logs..." stage.
