### PR TITLE
 	Start ecs agent after docker restart, and correct logic for ecs debug

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -434,6 +434,7 @@ enable_docker_debug()
 
           try "restart Docker daemon to enable debug mode"
           /sbin/service docker restart
+		  start ecs
         fi
 
         ok
@@ -458,12 +459,14 @@ enable_ecs_agent_debug()
         info "Debug mode is already enabled."
       else
         if [ -e /etc/ecs/ecs.config ]; then
-          echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
+		  try "back up original ECS config"
+		  cp /etc/ecs/ecs.config /etc/ecs/ecs.config.bak
+	    fi
+        echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
 
-          try "restart the Amazon ECS container agent to enable debug mode"
-          stop ecs; start ecs
-        fi
-
+        try "restart the Amazon ECS container agent to enable debug mode"
+        stop ecs; start ecs
+        
         ok
 
       fi

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -434,7 +434,7 @@ enable_docker_debug()
 
           try "restart Docker daemon to enable debug mode"
           /sbin/service docker restart
-		  start ecs
+          start ecs
         fi
 
         ok
@@ -459,9 +459,9 @@ enable_ecs_agent_debug()
         info "Debug mode is already enabled."
       else
         if [ -e /etc/ecs/ecs.config ]; then
-		  try "back up original ECS config"
-		  cp /etc/ecs/ecs.config /etc/ecs/ecs.config.bak
-	    fi
+          try "back up original ECS config"
+          cp /etc/ecs/ecs.config /etc/ecs/ecs.config.bak
+        fi
         echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
 
         try "restart the Amazon ECS container agent to enable debug mode"


### PR DESCRIPTION
In the Docker debug function, the Docker daemon is restarted to enable debugging. However, when the daemon is stopped, the ECS agent is killed, but it is never restarted. I've added a line to start the ECS agent after Docker is restarted.

For ECS agent debugging, the original code checks to see if the /etc/ecs/ecs.config file exists before adding the debug option. On the ECS-optimized AMI, this file does not exist by default, so the test would fail and then move on without actually adding debugging. This change still checks for the file, and it backs it up before appending the debug option.
