### PR TITLE
Remove dash from ps command

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -389,7 +389,7 @@ get_system_services()
   esac
 
   top -b -n 1 > ${info_system}/top.txt 2>&1
-  ps -fauxwww > ${info_system}/ps.txt 2>&1
+  ps fauxwww > ${info_system}/ps.txt 2>&1
   netstat -plant > ${info_system}/netstat.txt 2>&1
 
   ok


### PR DESCRIPTION
Using dash in ps command will show this message:
Warning: bad syntax, perhaps a bogus '-'? See /usr/share/doc/procps-3.2.8/FAQ
Because -ux means that ps will only list process by user "x", which does not exist