### PR TITLE
adding templates for community involvement.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+For urgent operational issues, please contact AWS Support directly.
+https://aws.amazon.com/premiumsupport/
+
+Please provide the following information:
+-->
+
+
+### Summary
+<!-- Please provide a brief outline of the issue -->
+
+
+### Description
+<!-- Provide detailed information about this issue -->
+
+
+
+<!-- Not required for feature requests -->
+### Expected Behavior
+
+
+### Observed Behavior
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md
+
+Please provide the following information:
+-->
+
+### Summary
+<!-- What does this pull request do? -->
+
+### Implementation details
+<!-- How are the changes implemented? -->
+
+### Testing
+<!-- How was this tested? -->
+- [ ] Works properly on Amazon Linux
+- [ ] Works properly on RHEL 7
+- [ ] Works properly on Debian 8
+- [ ] Works properly on Ubuntu 14.04
+
+New tests cover the changes: <!-- yes|no -->
+
+### Licensing
+<!--
+Please confirm that this contribution is under the terms of the Apache 2.0
+License.
+-->
+This contribution is under the terms of the Apache 2.0 License: <!-- yes -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to the Amazon ECS Log Collector
+
+Contributions to the Amazon ECS Log Collector should be made via GitHub [pull
+requests](https://github.com/awslabs/ecs-logs-collector/pulls) and discussed using
+GitHub [issues](https://github.com/awslabs/ecs-logs-collector/issues).
+
+### Before you start
+
+If you would like to make a significant change, it's a good idea to first open
+an issue to discuss it.
+
+## Licensing
+
+The Amazon ECS Log Collector is released under an [Apache
+2.0](http://aws.amazon.com/apache-2-0/) license. Any code you submit will be
+released under that license.
+
+For significant changes, we may ask you to sign a [Contributor License
+Agreement](http://en.wikipedia.org/wiki/Contributor_License_Agreement).


### PR DESCRIPTION
### Summary
This adds an issue and pr template as well as contribution guidelines based off of the [aws/amazon-ecs-agent](github.com/aws/amazon-ecs-agent) repo.


This contribution is under the terms of the Apache 2.0 License: yes
