### PR TITLE
Collect kernel message buffer contents

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -155,6 +155,7 @@ collect_brief() {
   is_diskfull
   get_sysinfo
   get_common_logs
+  get_kernel_logs
   get_mounts_info
   get_selinux_info
   get_iptables_info
@@ -281,11 +282,23 @@ get_common_logs()
   dstdir="${info_system}/var_log"
   mkdir -p ${dstdir}
 
-  for entry in syslog messages dmesg; do
+  for entry in syslog messages; do
     [ -e "/var/log/${entry}" ] && cp -fR /var/log/${entry} ${dstdir}/
   done
 
   ok
+}
+
+get_kernel_logs()
+{
+    try "collect kernel logs"
+    dstdir="${info_system}/kernel"
+    mkdir -p "$dstdir"
+    if [ -e "/var/log/dmesg" ]; then
+	cp -f /var/log/dmesg "$dstdir/dmesg.boot"
+    fi
+    dmesg > "$dstdir/dmesg.current"
+    ok
 }
 
 get_docker_logs()


### PR DESCRIPTION
Captures the output of `dmesg(8)` in addition to `/var/log/dmesg`. The former
contains the kernel's current message buffer contents, which information about
OOM situations and responses and that may not be captured in on-disk log files.

Testing performed on Debian and ECS Optimized Amazon Linux AMI:

__Amazon Linux:__
```
[ec2-user@ip-10-0-1-74 ecs-logs-collector]$ sudo ./ecs-logs-collector.sh 
Trying to check if the script is running as root... ok
Trying to check disk space usage... ok
Trying to collect system information... ok
Trying to collect common operating system logs... ok
Trying to collect kernel logs... ok
Trying to get mount points and volume information... ok
Trying to check SELinux status... ok
Trying to get iptables list... ok
Trying to detect installed packages... ok
Trying to detect active system services list... ok
Trying to gather Docker daemon information... ok
Trying to collect Amazon ECS container agent logs... ok
Trying to collect Amazon ECS init logs... cp: cannot stat '/var/log/ecs/ecs-init.log.*': No such file or directory
ok
Trying to inspect running Docker containers and gather Amazon ECS container agent data... ok
Trying to collect Docker daemon logs... ok
Trying to archive gathered log information... ok
[ec2-user@ip-10-0-1-74 ecs-logs-collector]$ ls -l collect/system/kernel/
total 52
-rw-r--r-- 1 root root 23674 Sep 11 18:56 dmesg.boot
-rw-r--r-- 1 root root 27945 Sep 11 18:56 dmesg.current
```

__Debian:__
```
admin@ip-10-0-0-218:~/ecs-logs-collector$ sudo ./ecs-logs-collector.sh 
Trying to check if the script is running as root... ok
Trying to check disk space usage... ok
Trying to collect system information... ok
Trying to collect common operating system logs... ok
Trying to collect kernel logs... ok
Trying to get mount points and volume information... ok
Trying to check SELinux status... not installed
Trying to get iptables list... ok
Trying to detect installed packages... ok
Trying to detect active system services list... Warning Unable to determine active services... 
ok
Trying to gather Docker daemon information... ok
Trying to collect Amazon ECS container agent logs... ok
Trying to collect Amazon ECS init logs... cp: cannot stat '/var/log/ecs/ecs-init.log.*': No such file or directory
ok
Trying to inspect running Docker containers and gather Amazon ECS container agent data... ok
Trying to collect Docker daemon logs... Warning The current operating system is not supported... 
ok
Trying to archive gathered log information... ok
admin@ip-10-0-0-218:~/ecs-logs-collector$ ls -l collect/system/kernel/
total 36
-rw-r--r-- 1 root root 34883 Sep 11 19:02 dmesg.current
```