### PR TITLE
Debug improvement

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -460,7 +460,7 @@ enable_docker_debug()
   case "${os_name}" in
     amazon)
 
-      if [ -e /etc/sysconfig/docker ] && grep -q "^OPTIONS=\"-D \$OPTIONS" /etc/sysconfig/docker
+      if [ -e /etc/sysconfig/docker ] && grep -q "^\s*OPTIONS=\"-D" /etc/sysconfig/docker
       then
         info "Debug mode is already enabled."
       else
@@ -489,7 +489,7 @@ enable_ecs_agent_debug()
   case "${os_name}" in
     amazon)
 
-      if [ -e /etc/ecs/ecs.config ] &&  grep -q "^ECS_LOGLEVEL=debug" /etc/ecs/ecs.config
+      if [ -e /etc/ecs/ecs.config ] &&  grep -q "^\s*ECS_LOGLEVEL=debug" /etc/ecs/ecs.config
       then
         info "Debug mode is already enabled."
       else

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -460,13 +460,13 @@ enable_docker_debug()
   case "${os_name}" in
     amazon)
 
-      if [ -e /etc/sysconfig/docker ] && grep -q "OPTIONS=\"-D" /etc/sysconfig/docker
+      if [ -e /etc/sysconfig/docker ] && grep -q "^OPTIONS=\"-D \$OPTIONS" /etc/sysconfig/docker
       then
         info "Debug mode is already enabled."
       else
 
         if [ -e /etc/sysconfig/docker ]; then
-          echo "OPTIONS=\"-D\"" >> /etc/sysconfig/docker
+          echo "OPTIONS=\"-D \$OPTIONS\"" >> /etc/sysconfig/docker
 
           try "restart Docker daemon to enable debug mode"
           /sbin/service docker restart

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -489,7 +489,7 @@ enable_ecs_agent_debug()
   case "${os_name}" in
     amazon)
 
-      if [ -e /etc/ecs/ecs.config ] &&  grep -q "ECS_LOGLEVEL=debug" /etc/ecs/ecs.config
+      if [ -e /etc/ecs/ecs.config ] &&  grep -q "^ECS_LOGLEVEL=debug" /etc/ecs/ecs.config
       then
         info "Debug mode is already enabled."
       else


### PR DESCRIPTION
I have 2 small improvements to the debug enable functions.

Firstly, the existing grep search strings will return true even if the debug lines are commented out. Adding a carat symbol at the beginning to the grep search string causes it to check that the search string is at the beginning of the line, thus avoiding false positives.

The second improvement is to include any existing $OPTIONS in the docker config file. The default config file on Amazon Linux sets some ulimits, and folks may enable other options such as exposing the Docker API via TCP. by setting OPTIONS to "-D $OPTIONS" debug is enabled while retaining any customisation to the options, therefore not changing the environment in ways that may affect debugging. This still works even if debug has been enabled in the existing options.
