### PR TITLE
Add useful troubleshooting information to the log collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following functions are supported:
 * Collect normal OS settings 
 * Collect Docker logs
 * Collect Amazon ECS agent Logs
+* Collect Instance network information
 * Enable debug mode for Docker and the Amazon ECS agent (only available for Amazon Linux)
 * Create a tar zip file in the same folder as the script
 
@@ -28,20 +29,22 @@ The following output shows this project running in normal mode:
 
 ```
 # bash ecs-logs-collector.sh
-Trying to check if it's running as root... ok
+Trying to check if the script is running as root... ok
 Trying to check disk space usage... ok
-Trying to collect system info... Amazon Linux AMI release 2016.03
-ok
-Trying to collect common system logs... ok
-Trying to get mountpoints and volumes info... ok
-Trying to get selinux status... ok
+Trying to collect system information... ok
+Trying to collect common operating system logs... ok
+Trying to get mount points and volume information... ok
+Trying to check SELinux status... ok
 Trying to get iptables list... ok
-Trying to get packages list... ok
-Trying to get system active services list... ok
-Trying to get docker info message... ok
-Trying to collect ecs logs... ok
-Trying to get docker inspect outputs of the containers... ok
-Trying to collect docker logs... Trying to pack gathered info... ok
+Trying to detect installed packages... ok
+Trying to detect active system services list... ok
+Trying to gather Docker daemon information... ok
+Trying to collect Amazon ECS container agent logs... ok
+Trying to collect Amazon ECS init logs... ok
+Trying to inspect running Docker containers and gather Amazon ECS container agent data... ok
+Trying to collect Docker daemon logs... ok
+Trying to get network information... ok
+Trying to archive gathered log information... ok
 ```
 
 ### Example output in debug mode
@@ -68,6 +71,7 @@ ok
 Trying to enable ecs agent debug mode... Trying to restart ECS agent to enable debug mode... stop: Unknown instance:
 ecs start/running, process 13188
 ok
+Trying to get network information... ok
 Trying to pack gathered info... ok
 ```
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -247,6 +247,8 @@ get_mounts_info()
     vgs > ${info_system}/vgs.txt
   fi
 
+  vmstat 1 5 > ${info_system}/vmstat.txt
+
   ok
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -165,6 +165,7 @@ collect_brief() {
   get_ecs_init_logs
   get_containers_info
   get_docker_logs
+  get_network_info
 }
 
 collect_debug() {
@@ -271,6 +272,18 @@ get_iptables_info()
 
   mkdir -p ${info_system}
   /sbin/iptables -nvL -t nat  > ${info_system}/iptables.txt
+
+  ok
+}
+
+get_network_info()
+{
+  try "get network information"
+
+  mkdir -p ${info_system}
+  /sbin/ip link > ${info_system}/ip_link.txt
+  /sbin/ip route ls > ${info_system}/ip_route.txt
+  /bin/netstat -i > ${info_system}/network_stats.txt
 
   ok
 }


### PR DESCRIPTION
Add vmststat and network information to the ecs-log-collector script

The vmststat output will allow troubleshooting if the Instance running the ECS tasks is facing I/O issues, useful to quickly check if the issue is because the EBS volume is running out IOPS

Network status will allow us to check if there is something wrong with the network interfaces or even if there was a change in the OS route table which is affecting docker.