### PR TITLE
Check that the Docker API responds before trying to use it.

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -416,11 +416,13 @@ is_docker_healthy()
 
       else
         warning "The Docker API is not responding. Some info will be unavailable."
+        return 2
       fi
     fi
 
   else
     warning "The Docker daemon is not running. Some info will be unavailable."
+    return 1
   fi
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -423,6 +423,9 @@ is_docker_healthy()
         warning "The Docker API is not responding. Some info will be unavailable."
         return 126
       fi
+    else
+        warning "Curl is needed in order to test Docker API. Continuing with normal tests."
+        return 0
     fi
 
   else
@@ -481,8 +484,10 @@ get_agent_info()
   pgrep agent > /dev/null
   if [[ "$?" -eq 0 ]]; then
 
-    if [ -e /usr/bin/curl ]; then
+    if [ `which curl` ]; then
       curl -s http://localhost:51678/v1/tasks | python -mjson.tool > ${info_system}/ecs-agent/agent-running-info.txt 2>&1
+    else
+      warning "Curl is required to gather information from the ECS Agent. Some info will be unavailable."
     fi
 
     ok

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -458,24 +458,24 @@ get_containers_info()
 get_agent_info()
 {
   try "gather Amazon ECS container agent data"
-  pgrep agent > /dev/null
+  mkdir -p ${info_system}/docker
 
+  if [ -e /var/lib/ecs/data/ecs_agent_data.json ]; then
+    cat  /var/lib/ecs/data/ecs_agent_data.json | python -mjson.tool > ${info_system}/ecs-agent/ecs_agent_data.txt 2>&1
+  fi
+
+  if [ -e /etc/ecs/ecs.config ]; then
+    cp -f /etc/ecs/ecs.config ${info_system}/ecs-agent/ 2>&1
+    if grep --quiet "ECS_ENGINE_AUTH_DATA" ${info_system}/ecs-agent/ecs.config; then
+      sed -i 's/ECS_ENGINE_AUTH_DATA=.*/ECS_ENGINE_AUTH_DATA=/g' ${info_system}/ecs-agent/ecs.config
+    fi
+  fi
+
+  pgrep agent > /dev/null
   if [[ "$?" -eq 0 ]]; then
-    mkdir -p ${info_system}/docker
 
     if [ -e /usr/bin/curl ]; then
       curl -s http://localhost:51678/v1/tasks | python -mjson.tool > ${info_system}/ecs-agent/agent-running-info.txt 2>&1
-    fi
-
-    if [ -e /var/lib/ecs/data/ecs_agent_data.json ]; then
-      cat  /var/lib/ecs/data/ecs_agent_data.json | python -mjson.tool > ${info_system}/ecs-agent/ecs_agent_data.txt 2>&1
-    fi
-
-    if [ -e /etc/ecs/ecs.config ]; then
-      cp -f /etc/ecs/ecs.config ${info_system}/ecs-agent/ 2>&1
-      if grep --quiet "ECS_ENGINE_AUTH_DATA" ${info_system}/ecs-agent/ecs.config; then
-        sed -i 's/ECS_ENGINE_AUTH_DATA=.*/ECS_ENGINE_AUTH_DATA=/g' ${info_system}/ecs-agent/ecs.config
-      fi
     fi
 
     ok

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -419,7 +419,7 @@ is_docker_healthy()
     fi
 
   else
-    die "The Docker daemon is not running."
+    warning "The Docker daemon is not running."
   fi
 }
 
@@ -427,20 +427,15 @@ get_docker_info()
 {
   try "gather Docker daemon information"
 
-  pgrep docker > /dev/null
-  if [[ "$?" -eq 0 ]]; then
-    mkdir -p ${info_system}/docker
+  mkdir -p ${info_system}/docker
 
-    docker info > ${info_system}/docker/docker-info.txt 2>&1
-    docker ps --all --no-trunc > ${info_system}/docker/docker-ps.txt 2>&1
-    docker images > ${info_system}/docker/docker-images.txt 2>&1
-    docker version > ${info_system}/docker/docker-version.txt 2>&1
+  docker info > ${info_system}/docker/docker-info.txt 2>&1
+  docker ps --all --no-trunc > ${info_system}/docker/docker-ps.txt 2>&1
+  docker images > ${info_system}/docker/docker-images.txt 2>&1
+  docker version > ${info_system}/docker/docker-version.txt 2>&1
 
-    ok
+  ok
 
-  else
-    die "The Docker daemon is not running."
-  fi
 }
 
 get_containers_info()
@@ -477,7 +472,7 @@ get_containers_info()
     ok
 
   else
-    die "The Amazon ECS container agent is not running."
+    warning "The Amazon ECS container agent is not running."
   fi
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -409,14 +409,16 @@ is_docker_healthy()
 
     if [ -e /usr/bin/curl ]; then
       try "Checking if Docker API is responding"
-      result=`curl  -S -m 60 --unix-socket /var/run/docker.sock http://localhost/_ping 2>&1`
+      result=`curl -s -m 60 --unix-socket /var/run/docker.sock http://localhost/_ping 2>&1`
       if [[ "$?" -eq 0 ]]; then
         
-        if [[ $result -eq "OK"]]; then
+        if [[ "$result" = "OK" ]]; then
           ok
           return 0
         else
           warning "The Docker API did not respond with OK. Some info will be unavailable."
+          echo "API output was:"
+          echo $result
           return 3
         fi
       else

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -402,13 +402,13 @@ get_system_services()
 
 is_docker_healthy()
 {
-  try "Checking if Docker is running"
+  try "confirm that Docker is running"
   pgrep docker > /dev/null
   if [[ "$?" -eq 0 ]]; then
     ok
 
-    if [ -e /usr/bin/curl ]; then
-      try "Checking if Docker API is responding"
+    if [ `which curl` ]; then
+      try "get a response from the Docker API"
       result=`curl -s -m 60 --unix-socket /var/run/docker.sock http://localhost/_ping 2>&1`
       if [[ "$?" -eq 0 ]]; then
         
@@ -416,14 +416,12 @@ is_docker_healthy()
           ok
           return 0
         else
-          warning "The Docker API did not respond with OK. Some info will be unavailable."
-          echo "API output was:"
-          echo $result
-          return 3
+          warning "The Docker API responded with $result. Some info will be unavailable."
+          return 1
         fi
       else
         warning "The Docker API is not responding. Some info will be unavailable."
-        return 2
+        return 126
       fi
     fi
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -411,9 +411,14 @@ is_docker_healthy()
       try "Checking if Docker API is responding"
       result=`curl  -S -m 60 --unix-socket /var/run/docker.sock http://localhost/_ping 2>&1`
       if [[ "$?" -eq 0 ]]; then
-        ok
-        return 0
-
+        
+        if [[ $result -eq "OK"]]; then
+          ok
+          return 0
+        else
+          warning "The Docker API did not respond with OK. Some info will be unavailable."
+          return 3
+        fi
       else
         warning "The Docker API is not responding. Some info will be unavailable."
         return 2


### PR DESCRIPTION
As mentioned in issue #13 the log collector will sometimes hang when querying Docker for information. This is usually the result of the Docker Daemon hanging and the Docker client does not time out when making requests.

To work around this I have split the data collection tasks off that need the Docker API to be responding vs the ones that don't. We then check if docker is running. If it is, we ping the Docker API, using a timeout of 60 seconds. If the API responds OK, then we can query the API for information. If not, inform the user that some information will be missing.

The important thing here is that data is still collected and packed, even if some tasks do not work, providing at least some of the info needed to diagnose issues.