### PR TITLE
handle the unrotated ecs-init log file too.

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -350,7 +350,7 @@ get_ecs_init_logs()
   dstdir="${info_system}/ecs-init"
 
   mkdir -p ${dstdir}
-  for entry in ecs-init.log.*; do
+  for entry in ecs-init.log*; do
     cp -fR /var/log/ecs/${entry} ${dstdir}/
   done
 


### PR DESCRIPTION
Until log rotation happens for ecs-init logs, there is only a single file, ecs-init.log. Bash globbing will miss it with the pattern `ls ecs-init.log.*`. Instead, use `ls ecs-init.log*`.