### PR TITLE
Fix issue #26 - Retrieve logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Run this project as the root user:
 # bash ecs-logs-collector.sh
 ```
 
+Confirm if the tarball file was successfully created ( it can be .tgz or .tar.gz )
+
+```
+#ls collect.*
+collect.tgz
+```
+### Retrieving the logs
+
+Download the tarball using your favorite Secure Copy tool
+
 ## Example output
 The project can be used in normal or debug mode (for Amazon Linux only).
 


### PR DESCRIPTION
Adding a quick reminder to retrieve the files after generate it as it's not mentioned the collect.tgz and collect.tar.gz anywere.