### PR TITLE
Collect both filter and nat tables from iptables

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -277,7 +277,8 @@ get_iptables_info()
   try "get iptables list"
 
   mkdir -p ${info_system}
-  /sbin/iptables -nvL -t nat  > ${info_system}/iptables.txt
+  /sbin/iptables -nvL -t filter > ${info_system}/iptables-filter.txt
+  /sbin/iptables -nvL -t nat  > ${info_system}/iptables-nat.txt
 
   ok
 }


### PR DESCRIPTION
Both the filter and nat tables are useful to have dumped for inspection.