### PR TITLE
modified function get_kernel_logs to print dmesg logs in human readab…

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -328,7 +328,7 @@ get_kernel_logs() {
   if [ -e "/var/log/dmesg" ]; then
     cp -f /var/log/dmesg "$dstdir/dmesg.boot"
   fi
-  dmesg > "$dstdir/dmesg.current"
+  dmesg -T > "$dstdir/dmesg.current"
   ok
 }
 


### PR DESCRIPTION
…le format

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds the "-T" flag to the "dmesg" command to make the timestamps human readable.
### Implementation details
<!-- How are the changes implemented? -->
Changed "dmesg" to "dmesg -T" in function "get_kernel_logs"
### Testing
<!-- How was this tested? -->
- [Y] Works properly on Amazon Linux
- [Y] Works properly on RHEL 7
- [Y] Works properly on Debian 8
- [Y] Works properly on Ubuntu 14.04

New tests cover the changes: <!-- yes|no --> 

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> Yes
