### PR TITLE
issue #37 dmesg logs Human Readable

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -329,6 +329,7 @@ get_kernel_logs() {
     cp -f /var/log/dmesg "$dstdir/dmesg.boot"
   fi
   dmesg > "$dstdir/dmesg.current"
+  dmesg -T > "$dstdir/dmesg.human.current"
   ok
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -329,7 +329,7 @@ get_kernel_logs() {
     cp -f /var/log/dmesg "$dstdir/dmesg.boot"
   fi
   dmesg > "$dstdir/dmesg.current"
-  dmesg -T > "$dstdir/dmesg.human.current"
+  dmesg --ctime > "$dstdir/dmesg.human.current"
   ok
 }
 


### PR DESCRIPTION
### Summary
Add the dmesg -T and human readable file for get_kernel_logs

### Implementation details
Added the `dmesg.human.current` to not generate breaking chains for users that use the script for automation purposes.

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [x] Works properly on RHEL 7
- [x] Works properly on Debian 8
- [x] Works properly on Ubuntu 14.04

New tests cover the changes: <!-- yes|no -->

ls kernel/
dmesg.boot  dmesg.current  dmesg.human.current

```
$tail dmesg.current
[  160.265280] br-41cf47afaed0: port 3(veth445963e) entered disabled state
[  160.274005] vethc2db2d5: renamed from eth0
[  160.310136] br-41cf47afaed0: port 3(veth445963e) entered disabled state
[  160.320650] device veth445963e left promiscuous mode
[  160.326053] br-41cf47afaed0: port 3(veth445963e) entered disabled state
[  160.338211] veth04efbcd: renamed from eth0
[  160.370555] br-41cf47afaed0: port 1(vetha2e1ffb) entered disabled state
[  160.380701] br-41cf47afaed0: port 1(vetha2e1ffb) entered disabled state
[  160.403030] device vetha2e1ffb left promiscuous mode
[  160.408153] br-41cf47afaed0: port 1(vetha2e1ffb) entered disabled state

$ tail dmesg.human.current
[Fri Jun 15 09:33:12 2018] br-41cf47afaed0: port 3(veth445963e) entered disabled state
[Fri Jun 15 09:33:12 2018] vethc2db2d5: renamed from eth0
[Fri Jun 15 09:33:12 2018] br-41cf47afaed0: port 3(veth445963e) entered disabled state
[Fri Jun 15 09:33:12 2018] device veth445963e left promiscuous mode
[Fri Jun 15 09:33:12 2018] br-41cf47afaed0: port 3(veth445963e) entered disabled state
[Fri Jun 15 09:33:12 2018] veth04efbcd: renamed from eth0
[Fri Jun 15 09:33:12 2018] br-41cf47afaed0: port 1(vetha2e1ffb) entered disabled state
[Fri Jun 15 09:33:12 2018] br-41cf47afaed0: port 1(vetha2e1ffb) entered disabled state
[Fri Jun 15 09:33:12 2018] device vetha2e1ffb left promiscuous mode
[Fri Jun 15 09:33:12 2018] br-41cf47afaed0: port 1(vetha2e1ffb) entered disabled state
```

### Licensing
This contribution is under the terms of the Apache 2.0 License:  Yes
