### PR TITLE
Provide support for CentOS

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -242,6 +242,8 @@ get_sysinfo() {
         os_name="amazon"
       elif grep --quiet "Red Hat" /etc/${found_file}; then
         os_name="redhat"
+      elif grep --quiet "CentOS" /etc/${found_file}; then
+        os_name="redhat"
       fi
       ;;
     debian_version)


### PR DESCRIPTION
### Summary
Add support for CentOS as some of the logs were missing.

### Implementation details
Detect CentOS and use the same collecting method as used for Red Hat.

### Testing
<!-- How was this tested? -->
- [X] Works properly on Amazon Linux
- [X] Works properly on RHEL 7
- [X] Works properly on Debian 8
- [X] Works properly on Ubuntu 14.04

New tests cover the changes: no

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
