### PR TITLE
Dump goroutine stacks

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -201,6 +201,7 @@ collect_brief() {
   get_ecs_agent_logs
   get_ecs_agent_info
   get_ecs_init_logs
+  get_docker_goroutines
 }
 
 enable_debug() {
@@ -582,6 +583,21 @@ enable_ecs_agent_debug() {
       warning "the current operating system is not supported."
       ;;
   esac
+}
+
+get_docker_goroutines() {
+  try "dump docker goroutine stacks"
+  dstdir="${info_system}/docker_stacks"
+  mkdir -p "${dstdir}"
+  # send SIGUSR1 to dump goroutines to
+  # /var/run/docker/goroutine-stacks-<date>.log
+  if kill -SIGUSR1 "$(pidof dockerd)" ; then
+    # find file and copy to our output
+    until find /var/run/docker/ -cmin -1 -type f -name "goroutine-stacks*.log" -exec cp -p '{}' "$dstdir" \; ; do
+      sleep 1
+    done
+    ok
+  fi
 }
 
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds a function get_docker_goroutines() that dumps stacktraces for all running goroutines into ${info_system}/docker_stacks.

### Implementation details
Sends SIGUSR1 to docker by sending SIGUSR1 to dockerd, then copying the resulting stacktrace file into ${info_system}/docker_stacks. 

### Testing
<!-- How was this tested? -->
Manually tested on the ecs-optimized ami.

- [x] Works properly on Amazon Linux (amzn-ami-2018.03.g-amazon-ecs-optimized)
- [ ] Works properly on RHEL 7
- [ ] Works properly on Debian 8
- [ ] Works properly on Ubuntu 14.04

New tests cover the changes: no

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes 
