### PR TITLE
Support for ECS 2 AMI

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -265,9 +265,6 @@ get_sysinfo() {
       ;;
   esac
 
-  mkdir -p ${info_system}
-  last > ${info_system}/last.txt
-
   ok
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -595,7 +595,7 @@ enable_ecs_agent_debug() {
 
         try "restart the Amazon ECS Container Agent to enable debug mode"
         systemctl restart ecs
-      ok
+        ok
 
       fi
       ;;
@@ -609,7 +609,7 @@ enable_ecs_agent_debug() {
 
         try "restart the Amazon ECS Container Agent to enable debug mode"
         systemctl restart ecs
-      ok
+        ok
 
       fi
       ;;

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -172,7 +172,7 @@ try_set_instance_infodir() {
       # Put logs into a directory for this instance.
       infodir="${infodir}/${instance_id}"
       info_system="${infodir}/system"
-      echo "$instance_id" | $info_system/instance-id.txt
+      echo "$instance_id | $info_system/instance-id.txt"
     else
       warning "unable to resolve instance metadata"
       return 1
@@ -569,7 +569,7 @@ enable_docker_debug() {
       else
 
         if [ -e /etc/sysconfig/docker ]; then
-          sed -i 's/^OPTIONS="\(.*\)/OPTIONS="-D \1/g' >> /etc/sysconfig/docker
+          sed -i 's/^OPTIONS="\(.*\)/OPTIONS="-D \1/g' /etc/sysconfig/docker
 
           try "restart Docker daemon to enable debug mode"
           /sbin/service docker restart
@@ -595,14 +595,10 @@ enable_ecs_agent_debug() {
       then
         info "Debug mode is already enabled."
       else
-        if [ -e /etc/ecs/ecs.config ]; then
-          echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
+        echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
 
-          try "restart the Amazon ECS Container Agent to enable debug mode"
-          stop ecs; start ecs
-        fi
-
-        ok
+        try "restart the Amazon ECS Container Agent to enable debug mode"
+        systemctl restart ecs
 
       fi
       ;;
@@ -612,14 +608,10 @@ enable_ecs_agent_debug() {
       then
         info "Debug mode is already enabled."
       else
-        if [ -e /etc/ecs/ecs.config ]; then
-          echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
+        echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
 
-          try "restart the Amazon ECS Container Agent to enable debug mode"
-          stop ecs; start ecs
-        fi
-
-        ok
+        try "restart the Amazon ECS Container Agent to enable debug mode"
+        systemctl restart ecs
 
       fi
       ;;

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -172,7 +172,6 @@ try_set_instance_infodir() {
       # Put logs into a directory for this instance.
       infodir="${infodir}/${instance_id}"
       info_system="${infodir}/system"
-      echo "$instance_id | $info_system/instance-id.txt"
     else
       warning "unable to resolve instance metadata"
       return 1
@@ -599,6 +598,7 @@ enable_ecs_agent_debug() {
 
         try "restart the Amazon ECS Container Agent to enable debug mode"
         systemctl restart ecs
+      ok
 
       fi
       ;;
@@ -612,6 +612,7 @@ enable_ecs_agent_debug() {
 
         try "restart the Amazon ECS Container Agent to enable debug mode"
         systemctl restart ecs
+      ok
 
       fi
       ;;

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -430,7 +430,7 @@ get_system_services() {
       chkconfig --list > ${info_system}/services.txt 2>&1
       ;;
     amazon2)
-      chkconfig --list > ${info_system}/services.txt 2>&1
+      systemctl list-units > ${info_system}/services.txt 2>&1
       ;;
     redhat)
       /bin/systemctl list-units > ${info_system}/services.txt 2>&1
@@ -568,7 +568,7 @@ enable_docker_debug() {
           sed -i 's/^OPTIONS="\(.*\)/OPTIONS="-D \1/g' /etc/sysconfig/docker
 
           try "restart Docker daemon to enable debug mode"
-          /sbin/service docker restart
+          systemctl restart docker.service
         fi
 
         ok
@@ -594,7 +594,7 @@ enable_ecs_agent_debug() {
         echo "ECS_LOGLEVEL=debug" >> /etc/ecs/ecs.config
 
         try "restart the Amazon ECS Container Agent to enable debug mode"
-        systemctl restart ecs
+        stop ecs; start ecs
         ok
 
       fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

- Provides support for the new ECS 2 AMI
- Removed broken and unnecessary echo within the try_set_instance_infodir() function.
- Using mode debug, it created an additional directory to write the output of "last" because it loaded twice the init() function. I removed it from the get_sysinfo() function, because first I don't know why this is included in this function since it's not system info per se and second I don't see any reason why we may need this information, I've never used it.

### Testing
<!-- How was this tested? -->
- [X] Works properly on Amazon Linux
- [X] Works properly on Amazon Linux 2
- [X] Works properly on RHEL 7
- [X] Works properly on Debian 8
- [X] Works properly on Ubuntu 14.04

New tests cover the changes: yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
