### PR TITLE
Cleaning code to remove some errors on console

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -172,7 +172,8 @@ try_set_instance_infodir() {
       # Put logs into a directory for this instance.
       infodir="${infodir}/${instance_id}"
       info_system="${infodir}/system"
-      echo "$instance_id" | $info_system/instance-id.txt
+      mkdir -p ${info_system}
+      echo "$instance_id" > ${info_system}/instance-id.txt
     else
       warning "unable to resolve instance metadata"
       return 1
@@ -392,8 +393,8 @@ get_ecs_init_logs() {
   fi
 
   mkdir -p ${dstdir}
-  for entry in ecs-init.log*; do
-    cp -fR /var/log/ecs/${entry} ${dstdir}/
+  for entry in $(ls /var/log/ecs/ecs-init.log* 1> /dev/null 2>&1); do
+    cp -fR ${entry} ${dstdir}/
   done
 
   ok

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -397,7 +397,7 @@ get_ecs_init_logs() {
   fi
 
   mkdir -p ${dstdir}
-  for entry in $(ls /var/log/ecs/ecs-init.log* 1> /dev/null 2>&1); do
+  for entry in $(ls /var/log/ecs/ecs-init.log* 2>/dev/null); do
     cp -fR ${entry} ${dstdir}/
   done
 


### PR DESCRIPTION
### Summary
Fixes 2 errors on the console:

Trying to check if the script is running as root ... ok
Trying to resolve instance-id ... /usr/local/bin/ecs-logs-collector.sh: line 175: /usr/local/bin/collect/i-0873c22d6476fe6d3/system/instance-id.txt: No such file or directory
ok
Trying to collect system information ... ok
Trying to check disk space usage ... ok
Trying to collect common operating system logs ... ok
Trying to collect kernel logs ... ok
Trying to get mount points and volume information ... ok
Trying to check SELinux status ... ok
Trying to get iptables list ... ok
Trying to detect installed packages ... ok
Trying to detect active system services list ... ok
Trying to gather Docker daemon information ... ok
Trying to inspect all Docker containers ... ok
Trying to collect Docker daemon logs ... ok
Trying to collect Amazon ECS Container Agent logs ... ok
Trying to collect Amazon ECS Container Agent state and config ... ok
Trying to collect Amazon ECS Container Agent engine data ... ok
Trying to collect Amazon ECS init logs ... cp: cannot stat '/var/log/ecs/ecs-init.log*': No such file or directory
ok
Trying to archive gathered log information ... ok

### Implementation details
Creating folder to copy instance id and using a redirect instead of pipe to echo.
ECS init logs are optional and not necessarily present when not running and Amazon AMI.

### Testing
- [X] Works properly on Amazon Linux
- [X] Works properly on RHEL 7
- [X] Works properly on Debian 8
- [X] Works properly on Ubuntu 14.04

New tests cover the changes: no

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
