### PR TITLE
Collect agent boltdb data file

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -448,6 +448,11 @@ get_ecs_agent_info() {
     python -mjson.tool < /var/lib/ecs/data/ecs_agent_data.json > "$info_system"/ecs-agent/ecs_agent_data.txt 2>&1
   fi
 
+  if [ -e /var/lib/ecs/data/agent.db ]; then
+    cp -f /var/lib/ecs/data/agent.db "$info_system"/ecs-agent/agent.db 2>&1
+    chmod +r "$info_system"/ecs-agent/agent.db
+  fi
+
   if [ -e /etc/ecs/ecs.config ]; then
     cp -f /etc/ecs/ecs.config "$info_system"/ecs-agent/ 2>&1
     if grep --quiet "ECS_ENGINE_AUTH_DATA" "$info_system"/ecs-agent/ecs.config; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Since version [1.44.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.44.0), the ecs agent starts to use boltdb as data store, and its state is stored by default in `/var/lib/ecs/data/agent.db`. This change updates the script to collect the boltdb data file of the agent.

### Implementation details
<!-- How are the changes implemented? -->
Done at the same place where we collect  `/var/lib/ecs/data/ecs_agent_data.json`. Added read permission to the file since by default only root can view the file.

### Testing
<!-- How was this tested? -->
- [X] Works properly on Amazon Linux: tested on AMI `amzn-ami-2018.03.20200820-amazon-ecs-optimized`
- [X] Works properly on Amazon Linux 2: tested on AMI `amzn2-ami-ecs-hvm-2.0.20200820-x86_64-ebs`
- [X] Works properly on RHEL 7: tested on AMI `RHEL-7.7_HVM-20190923-x86_64-0-Hourly2-GP2`
- [X] Works properly on Debian 9: tested on AMI `debian-stretch-hvm-x86_64-gp2-2019-02-19-26620`
- [X] Works properly on Ubuntu 14.04: tested on AMI `ubuntu/images/hvm-io1/ubuntu-trusty-14.04-amd64-server-20191107`

New tests cover the changes: <!-- yes|no --> no

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
