### PR TITLE
added get_open_files function

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -168,6 +168,7 @@ collect_brief() {
   get_docker_daemon_json
   get_ecs_agent_logs
   get_ecs_agent_info
+  get_open_files
 }
 
 enable_debug() {
@@ -306,6 +307,16 @@ get_iptables_info() {
   mkdir -p "$info_system"
   iptables -nvL -t filter > "$info_system"/iptables-filter.txt
   iptables -nvL -t nat  > "$info_system"/iptables-nat.txt
+
+  ok
+}
+
+get_open_files() {
+  try "get open files list"
+
+  mkdir -p "$info_system"
+  for d in /proc/*/fd; do echo "$d"; find "$d" -maxdepth 1 | wc -l; done > "$info_system"/open-file-counts.txt
+  ls -l /proc/*/fd > "$info_system"/open-file-details.txt
 
   ok
 }
@@ -544,7 +555,7 @@ get_docker_systemd_config(){
   if [[ "$init_type" != "systemd" ]]; then
     return 0
   fi
-   
+
   try "collect Docker systemd unit file"
 
   mkdir -p "${info_system}"/docker
@@ -554,8 +565,8 @@ get_docker_systemd_config(){
     rm -f "$info_system/docker/docker.service"
     warning "docker.service not found"
   fi
-  
-  try "collect containerd systemd unit file"  
+
+  try "collect containerd systemd unit file"
   if systemctl cat containerd.service > "${info_system}"/docker/containerd.service 2>/dev/null; then
    ok
   else


### PR DESCRIPTION
This adds two files to the collect bundle: open-file-details.txt and
open-file-counts.txt

open-file-counts.txt provides just a count of the number of open files
that each process has:

```
$ head open-file-counts.txt
/proc/1/fd
49
/proc/10/fd
1
/proc/1053/fd
1
/proc/10546/fd
22
/proc/1057/fd
1
```

open-file-details.txt provides a detailed look at the file descriptors
that each process has:

```
$ head open-file-details.txt
/proc/1/fd:
total 0
lrwx------ 1 root root 64 Oct 20 23:36 0 -> /dev/null
lrwx------ 1 root root 64 Oct 20 23:36 1 -> /dev/null
lr-x------ 1 root root 64 Oct 21 01:26 10 -> anon_inode:inotify
lr-x------ 1 root root 64 Oct 21 01:26 11 -> /proc/swaps
lrwx------ 1 root root 64 Oct 21 01:26 12 -> socket:[1995]
lrwx------ 1 root root 64 Oct 21 01:26 13 -> socket:[20706]
lr-x------ 1 root root 64 Oct 21 01:26 14 -> anon_inode:inotify
lr-x------ 1 root root 64 Oct 21 01:26 16 -> anon_inode:inotify
```


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [x] Works properly on Amazon Linux 2
- [x] Works properly on RHEL 7
- [x] Works properly on Debian 8
- [x] Works properly on Ubuntu 14.04
- [x] Works properly on Ubuntu 16.04
- [x] Works properly on Ubuntu 18.04

New tests cover the changes: <!-- yes|no -->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
