### PR TITLE
collect containerd logs when on systemd system

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -348,13 +348,14 @@ get_kernel_logs() {
 }
 
 get_docker_logs() {
-  try "collect Docker daemon logs"
+  try "collect Docker and containerd daemon logs"
 
   dstdir="${info_system}/docker_log"
   mkdir -p "$dstdir"
   case "${init_type}" in
     systemd)
       journalctl -u docker > "${dstdir}"/docker
+      journalctl -u containerd > "${info_system}"/containerd.log
       ;;
     other)
       for entry in docker upstart/docker; do


### PR DESCRIPTION
### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [x] Works properly on Amazon Linux 2
- [x] Works properly on RHEL 7
- [x] Works properly on Debian 8
- [x] Works properly on Ubuntu 14.04
- [x] Works properly on Ubuntu 16.04
- [x] Works properly on Ubuntu 18.04

New tests cover the changes: <!-- yes|no -->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
