### PR TITLE
Copy ECS Agent logs recursively

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -385,7 +385,7 @@ get_ecs_agent_logs() {
 
   mkdir -p "$dstdir"
 
-  cp -f /var/log/ecs/* "$dstdir"/
+  cp -Rf /var/log/ecs/* "$dstdir"/
 
   ok
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The aim of this change is to include ECS Execute Command Agent logs in the future. These logs will be inside the regular ECS Agent Log directory, therefore a recursive copy will include Exec Command logs.

### Implementation details
<!-- How are the changes implemented? -->

`cp -f` -> `cp -Rf`

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [x] Works properly on Amazon Linux 2
- [x] Works properly on RHEL 7
- [x] Works properly on Debian 8
- [x] Works properly on Ubuntu 14.04
- [x] Works properly on Ubuntu 16.04
- [x] Works properly on Ubuntu 18.04


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
