### PR TITLE
Add docker stats output to log collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following functions are supported:
 Run this project as the root user:
 
 ```
-# curl -O https://raw.githubusercontent.com/awslabs/ecs-logs-collector/master/ecs-logs-collector.sh
+# curl -O https://raw.githubusercontent.com/aws/amazon-ecs-logs-collector/master/ecs-logs-collector.sh
 # bash ecs-logs-collector.sh
 ```
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -442,9 +442,10 @@ get_docker_info() {
   if pgrep dockerd > /dev/null ; then
 
     timeout 20 docker info > "$info_system"/docker/docker-info.txt 2>&1 || echo "Timed out, ignoring \"docker info output \" "
-    timeout 20 docker ps --all --no-trunc > "$info_system"/docker/docker-ps.txt 2>&1 || echo "Timed out, ignoring \"docker ps --all --no-truc output \" "
+    timeout 20 docker ps --all --no-trunc > "$info_system"/docker/docker-ps.txt 2>&1 || echo "Timed out, ignoring \"docker ps --all --no-trunc output \" "
     timeout 20 docker images > "$info_system"/docker/docker-images.txt 2>&1 || echo "Timed out, ignoring \"docker images output \" "
     timeout 20 docker version > "$info_system"/docker/docker-version.txt 2>&1 || echo "Timed out, ignoring \"docker version output \" "
+    timeout 60 docker stats --all --no-trunc --no-stream > "$info_system"/docker/docker-stats.txt 2>&1 || echo "Timed out, ignoring \"docker stats\" output"
 
     ok
   else


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

fixes readme link to script

adds `docker stats` output to docker/ directory in log collection

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [x] Works properly on Amazon Linux 2
- [x] Works properly on Debian 8
- [x] Works properly on Ubuntu 18.04

New tests cover the changes: <!-- yes|no -->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
