### PR TITLE
collect /var/log/amazon/ directory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,11 +15,8 @@ Please provide the following information:
 <!-- How was this tested? -->
 - [ ] Works properly on Amazon Linux
 - [ ] Works properly on Amazon Linux 2
-- [ ] Works properly on RHEL 7
-- [ ] Works properly on Debian 8
-- [ ] Works properly on Ubuntu 14.04
-- [ ] Works properly on Ubuntu 16.04
-- [ ] Works properly on Ubuntu 18.04
+- [ ] Works properly on Ubuntu 20.04
+- [ ] Works properly on CentOS 8
 
 New tests cover the changes: <!-- yes|no -->
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -167,6 +167,7 @@ collect_brief() {
   get_docker_sysconfig
   get_docker_daemon_json
   get_ecs_agent_logs
+  get_amazon_logs
   get_ecs_agent_info
   get_open_files
 }
@@ -369,6 +370,27 @@ get_docker_logs() {
       return 1
       ;;
   esac
+
+  ok
+}
+
+get_amazon_logs() {
+  try "collect Amazon log directory"
+
+  dstdir="${info_system}/amazon_logs"
+
+  if [ ! -d /var/log/amazon ]; then
+    failed "amazon log directory does not exist"
+    return 1
+  fi
+
+  mkdir -p "$dstdir"
+
+  cp -f -r /var/log/amazon/* "$dstdir"/
+
+  # add permission for all users to read the files grabbed from /var/log/amazon.
+  find "$dstdir" -type d -exec chmod 755 {} +
+  find "$dstdir" -type f -exec chmod 644 {} +
 
   ok
 }


### PR DESCRIPTION
This directory can often contain /var/log/amazon/ssm and /var/log/amazon/efs

After this change these are both collected in the bundle directory:

```
$ ll amazon_logs/
total 8
drwxr-xr-x 2 root root 4096 Mar 10 21:27 efs
drwxr-xr-x 4 root root 4096 Mar 10 21:27 ssm

$ ll amazon_logs/ssm/
total 112
-rw-r--r-- 1 root root 79941 Mar 10 21:27 amazon-ssm-agent.log
-rw-r--r-- 1 root root 18802 Mar 10 21:27 AmazonSSMAgent-update.txt
drwxr-xr-x 2 root root  4096 Mar 10 21:27 audits
drwxr-xr-x 3 root root  4096 Mar 10 21:27 download
-rw-r--r-- 1 root root   565 Mar 10 21:27 errors.log
```

I've also updated the pull request template to only ask for testing on more modern and relevant OS variants.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [x] Works properly on Amazon Linux 2
- [x] Works properly on Ubuntu 20.04
- [x] Works properly on CentOS 8

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
