### PR TITLE
Added Cloud-init-logs function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The following functions are supported:
 * Collect Operating System logs
 * Collect Operating System settings
 * Collect Docker logs
+* Collect Cloud-init logs
 * Collect Amazon ECS agent Logs
 * Enable debug mode for Docker and the Amazon ECS agent (only available for Systemd init systems and Amazon Linux)
 * Create a tar zip file in the same folder as the script
@@ -73,6 +74,7 @@ Trying to gather Docker daemon information ... ok
 Trying to inspect all Docker containers ... ok
 Trying to collect Docker daemon logs ... ok
 Trying to collect Amazon ECS Container Agent logs ... ok
+Trying to collect Cloud Init logs ... ok
 Trying to collect Amazon ECS Container Agent state and config ... ok
 Trying to collect Amazon ECS Container Agent engine data ... ok
 Trying to archive gathered log information ... ok

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -169,6 +169,7 @@ collect_brief() {
   get_docker_sysconfig
   get_docker_daemon_json
   get_ecs_agent_logs
+  get_cloud_init_logs
   get_ecs_agent_info
   get_open_files
   get_os_release
@@ -445,6 +446,19 @@ get_ecs_agent_logs() {
   mkdir -p "$dstdir"
 
   cp -f /var/log/ecs/* "$dstdir"/
+
+  ok
+}
+
+get_cloud_init_logs() {
+  try "collect Cloud Init logs"
+
+  dstdir="${info_system}/cloud_init_logs"
+
+  mkdir -p "$dstdir"
+
+  cp -f /var/log/cloud-init.log "$dstdir"/
+  cp -f /var/log/cloud-init-output.log "$dstdir"/
 
   ok
 }


### PR DESCRIPTION

What does this pull request do? 
Collects the Cloud-init logs

### Implementation details
Presently ECS log collector script does not collect the bootstrapping details that is logged in cloud-init log file, cloud-init execution logs helps lot in effective troubleshooting. While sharing the ECS instance log with AWS support, we have to manually collect this logs. It would be useful if can add this as a part of ECS log collector script itself.

### Testing
<!-- How was this tested? -->
- [ ] Works properly on Amazon Linux 2 -- yes
- [ ] Works properly on Ubuntu 20.04 -- yes
- [ ] Works properly on CentOS 8 --yes

New tests cover the changes: <!-- yes|no --> yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
