### PR TITLE
get ip addr and brctl info

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -177,6 +177,7 @@ collect_brief() {
   get_lsmod_info
   get_cgroupv2_events
   get_systemd_slice_info
+  get_veth_info
 }
 
 enable_debug() {
@@ -340,6 +341,20 @@ get_mounts_info() {
     lvdisplay > "$info_system"/lvdisplay.txt
     vgdisplay > "$info_system"/vgdisplay.txt
     pvdisplay > "$info_system"/pvdisplay.txt
+  fi
+
+  ok
+}
+
+get_veth_info() {
+  try "get veth info"
+
+  if command -v brctl >/dev/null; then
+    brctl show > "$info_system"/brctlshow.txt
+  fi
+
+  if command -v ip >/dev/null; then
+    ip addr show > "$info_system"/ipaddrshow.txt
   fi
 
   ok


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Get veth and bridge information from `ip addr show` and `brctl show`, if these commands are available on the instance.

example ipaddrshow.txt:

```
% cat collect/i-09cd2db66608cd0f8/ipaddrshow.txt 
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 02:0c:1b:23:6d:ff brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.75/24 brd 10.0.0.255 scope global dynamic eth0
       valid_lft 3244sec preferred_lft 3244sec
    inet6 fe80::c:1bff:fe23:6dff/64 scope link 
       valid_lft forever preferred_lft forever
3: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 02:42:ce:ba:e3:68 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:ceff:feba:e368/64 scope link 
       valid_lft forever preferred_lft forever
4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 02:9c:9b:6d:68:19 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.139/24 brd 10.0.0.255 scope global dynamic eth1
       valid_lft 3281sec preferred_lft 3281sec
    inet6 fe80::9c:9bff:fe6d:6819/64 scope link 
       valid_lft forever preferred_lft forever
6: veth185f02a@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP group default 
    link/ether 92:dc:31:a5:8c:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 fe80::90dc:31ff:fea5:8c1d/64 scope link 
       valid_lft forever preferred_lft forever
8: veth55e22d4@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP group default 
    link/ether 6e:c0:41:77:96:6e brd ff:ff:ff:ff:ff:ff link-netnsid 1
    inet6 fe80::6cc0:41ff:fe77:966e/64 scope link 
       valid_lft forever preferred_lft forever
10: veth4e5c75b@if9: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP group default 
    link/ether 42:7f:fd:78:69:a4 brd ff:ff:ff:ff:ff:ff link-netnsid 2
    inet6 fe80::407f:fdff:fe78:69a4/64 scope link 
       valid_lft forever preferred_lft forever
12: veth13035a2@if11: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP group default 
    link/ether e6:e1:46:ae:ce:83 brd ff:ff:ff:ff:ff:ff link-netnsid 4
    inet6 fe80::e4e1:46ff:feae:ce83/64 scope link 
       valid_lft forever preferred_lft forever
14: veth489cf2f@if13: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP group default 
    link/ether 52:1f:04:4d:55:c9 brd ff:ff:ff:ff:ff:ff link-netnsid 3
    inet6 fe80::501f:4ff:fe4d:55c9/64 scope link 
       valid_lft forever preferred_lft forever
```

example brctlshow.txt:
```
% cat collect/i-09cd2db66608cd0f8/brctlshow.txt 
bridge name	bridge id		STP enabled	interfaces
docker0		8000.0242cebae368	no		veth13035a2
							veth185f02a
							veth489cf2f
							veth4e5c75b
							veth55e22d4
```

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux 2
- [x] Works properly on Ubuntu 20.04
- [x] Works properly on CentOS 8

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
