### PR TITLE
Collect GPU Info for GPU Container Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,23 @@ Trying to detect installed packages ... ok
 Trying to detect active system services list ... ok
 Trying to gather Docker daemon information ... ok
 Trying to inspect all Docker containers ... ok
-Trying to collect Docker daemon logs ... ok
+Trying to collect Docker and containerd daemon logs ... ok
+Trying to collect Docker systemd unit file ... ok
+Trying to collect containerd systemd unit file ... ok
+Trying to collect Docker sysconfig ... ok
+Trying to collect Docker storage sysconfig ... ok
+Trying to collect Docker daemon.json ... ok
 Trying to collect Amazon ECS Container Agent logs ... ok
 Trying to collect Amazon ECS Container Agent state and config ... ok
 Trying to collect Amazon ECS Container Agent engine data ... ok
+Trying to get open files list ... ok
+Trying to collect /etc/os-release ... ok
+Trying to get uname kernel info ... ok
+Trying to get dmidecode info ... ok
+Trying to get lsmod info ... ok
+Trying to collect systemd slice info ... ok
+Trying to get veth info ... ok
+Trying to get gpu info ... ok
 Trying to archive gathered log information ... ok
 ```
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -794,7 +794,6 @@ get_gpu_info() {
     mkdir -p "$info_system"/gpu
     nvidia-smi -L > "$info_system"/gpu/gpu-list.txt
     nvidia-smi -q > "$info_system"/gpu/gpu-info.txt
-
   fi
 
   ok

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -785,7 +785,7 @@ enable_ecs_agent_debug() {
   fi
 }
 
-# nvidia-smi is a tool available on GOU based AMIs provides detailed
+# nvidia-smi is a tool available on GPU based AMIs provides detailed
 # information about the GPU present on the VM.
 get_gpu_info() {
   try "get gpu info"

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -178,6 +178,7 @@ collect_brief() {
   get_cgroupv2_events
   get_systemd_slice_info
   get_veth_info
+  get_gpu_info
 }
 
 enable_debug() {
@@ -784,6 +785,20 @@ enable_ecs_agent_debug() {
   fi
 }
 
+# nvidia-smi is a tool available on GOU based AMIs provides detailed
+# information about the GPU present on the VM.
+get_gpu_info() {
+  try "get gpu info"
+
+  if command -v nvidia-smi &>/dev/null; then
+    mkdir -p "$info_system"/gpu
+    nvidia-smi -L > "$info_system"/gpu/gpu-list.txt
+    nvidia-smi -q > "$info_system"/gpu/gpu-info.txt
+
+  fi
+
+  ok
+}
 # --------------------------------------------------------------------------------------------
 
 parse_options "$@"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Added a routine to collect GPU details for GPU Container Instances

### Implementation details
This change will add output of:
1. nvidia-smi -L listing GPUs
3. nvidia-smi -q Details of all GPUs


### Testing
<!-- How was this tested? -->
- [Y] Works properly on Amazon Linux 2
- [Y] Works properly on Ubuntu 20.04
- [Y] Works properly on CentOS 8

New tests cover the changes: yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
