### PR TITLE
al2023 updates and some more

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Please provide the following information:
 ### Testing
 <!-- How was this tested? -->
 - [ ] Works properly on Amazon Linux 2
+- [ ] Works properly on Amazon Linux 2023
 - [ ] Works properly on Ubuntu 20.04
 - [ ] Works properly on CentOS 8
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 ecs-logs-collector
-Copyright 2011-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ The following functions are supported:
 Run this project as the root user:
 
 ```
-# curl -O https://raw.githubusercontent.com/aws/amazon-ecs-logs-collector/master/ecs-logs-collector.sh
-# bash ecs-logs-collector.sh
+curl -O https://raw.githubusercontent.com/aws/amazon-ecs-logs-collector/master/ecs-logs-collector.sh
+bash ecs-logs-collector.sh
 ```
 
 Confirm if the tarball file was successfully created (it can be .tgz or .tar.gz)
 
 ```
-#ls collect*
+# ls collect*
 collect-i-ffffffffffffffffff-YYYYMMDDHHmm.tgz
 
 collect:

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -418,7 +418,6 @@ get_common_logs() {
     [ -e "/var/log/${entry}" ] && cp -f /var/log/${entry} "$dstdir"/
   done
 
-
   ok
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018 Amazon.com, Inc. or its affiliates.
-# All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -467,7 +467,7 @@ get_ecs_agent_logs() {
 
   mkdir -p "$dstdir"
 
-  cp -f /var/log/ecs/* "$dstdir"/
+  cp -f -r /var/log/ecs/* "$dstdir"/
 
   ok
 }

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -406,12 +406,18 @@ get_open_files() {
 get_common_logs() {
   try "collect common operating system logs"
 
+  mkdir -p "$info_system"
+  if command -v journalctl >/dev/null; then
+      journalctl > "${info_system}"/system.log
+  fi
+
   dstdir="${info_system}/var_log"
   mkdir -p "$dstdir"
 
   for entry in syslog messages; do
     [ -e "/var/log/${entry}" ] && cp -f /var/log/${entry} "$dstdir"/
   done
+
 
   ok
 }

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -278,7 +278,9 @@ try_set_instance_collectdir() {
 
   if test -z "$instance_id" && command -v curl > /dev/null; then
     info "getting instance id from ec2 metadata endpoint"
-    instance_id=$(curl --max-time 3 -s http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
+    imds="http://169.254.169.254/latest"
+    token=$(curl -sS --retry 3 -X PUT "${imds}/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
+    instance_id=$(curl -sS --retry 3 -H "X-aws-ec2-metadata-token: $token" "${imds}/meta-data/instance-id" 2>/dev/null)
   fi
 
   if [ -n "$instance_id" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR updates the `ecs-logs-collector.sh` script with AL2023 related changes, and a few more misc updates.

### Implementation details
<!-- How are the changes implemented? -->
1. Collect system logs from systemd journal if `journalctl` is available.
2. Use token since its required for IMDSv2 (enabled by default on AL2023). Tokens are optional for IMDSv1. This is also applicable to other OS like AL2 where customer may enable IMDSv2.  We query IMDS to get the instance ID.
3. Collect logs from subfolders within `/var/log/ecs/` too, like `exec` and `service-connect` when available.
4. Remove '#' from commands in README for convenient copy and run.
5. Update copyright header and NOTICE.
6. Add AL2023 to the PR template.


### Testing
<!-- How was this tested? -->
- [✔️] Works properly on Amazon Linux 2
- [✔️] Works properly on Amazon Linux 2023
- [✔️] Works properly on Ubuntu 20.04
- [✔️] Works properly on CentOS 8

New tests cover the changes: <!-- yes|no -->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
