### PR TITLE
Add NVIDIA open kmod version to logs

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -808,6 +808,15 @@ get_gpu_info() {
     nvidia-smi -q > "$info_system"/gpu/gpu-info.txt
   fi
 
+  # get open kernel module version
+  if [ -d /var/lib/dkms-archive/nvidia-open ]; then
+    ls /var/lib/dkms-archive/nvidia-open > "$info_system"/gpu/gpu-open-module.txt
+  fi
+
+  if command -v modinfo nvidia &>/dev/null; then
+    modinfo nvidia > "$info_system"/gpu/gpu-installed-kmod.txt
+  fi
+
   ok
 }
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds a section to the GPU log collection to pull the specific NVIDIA Open Kernel Module .tar file version for help debugging installation issues.

### Implementation details
Added a check for the existence of the `/var/lib/dkms-archive/nvidia-open` directory.  If this exists, then there will be an accompanying .tar file which we can just ls to the output file:
```
[nvidia-open]$ ls
nvidia-open-535.129.03-kernel4.14.330-250.540.amzn2.x86_64-x86_64.dkms.tar.gz
```

### Testing
<!-- How was this tested? -->
- [ x ] Works properly on Amazon Linux 2
- [ x ] Works properly on Amazon Linux 2023
- [ x ] Works properly on Ubuntu 20.04
- [ x ] Works properly on CentOS 8

New tests cover the changes: no

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
