### PR TITLE
Addition of disable-debug mode to ECS Logs Collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following functions are supported:
 * Collect Docker logs
 * Collect Amazon ECS agent Logs
 * Enable debug mode for Docker and the Amazon ECS agent (only available for Systemd init systems and Amazon Linux)
+* Disable debug mode for Docker and the Amazon ECS agent (only available for Systemd init systems and Amazon Linux)
 * Create a tar zip file in the same folder as the script
 
 ## Usage
@@ -33,11 +34,11 @@ i-ffffffffffffffffff
 Download the tarball using your favourite Secure Copy tool.
 
 ## Example output
-The project can be used in normal or enable-debug mode. Enable debug is only available for Systemd init systems and Amazon Linux.
+The project can be used in normal, enable-debug or disable-debug mode. Enable & Disable debug is only available for Systemd init systems and Amazon Linux.
 
 ```
 # bash ecs-logs-collector.sh --help
-USAGE: ./ecs-logs-collector.sh [--mode=[brief|enable-debug]]
+USAGE: ./ecs-logs-collector.sh [--mode=[brief|enable-debug|disable-debug]]
        ./ecs-logs-collector.sh --help
 
 OPTIONS:
@@ -51,6 +52,8 @@ MODES:
      enable-debug  Enables debug mode for the Docker daemon and the Amazon
                    ECS Container Agent. Only supported on Systemd init systems
                    and Amazon Linux.
+     disable-debug Disables debug mode for the Docker daemon and the Amazon
+                   ECS Container Agent. reverse of enable-debug option.
 ```
 
 ### Example output in normal mode
@@ -102,6 +105,20 @@ Trying to enable debug mode for the Docker daemon ... ok
 Trying to restart Docker daemon to enable debug mode ... ok
 Trying to enable debug mode for the Amazon ECS Container Agent ... ok
 Trying to restart the Amazon ECS Container Agent to enable debug mode ... ok
+```
+
+### Example output in disable-debug mode
+The following output shows this project disabling debug mode for the Docker daemon and the Amazon ECS Container Agent. This mode only works on Amazon Linux OS and Systemd init systems such as RHEL 7 and Ubuntu 16.04. Note that disable-debug mode restarts Docker and the Amazon ECS agent.
+
+```
+# bash ecs-logs-collector.sh --mode=disable-debug
+Trying to check if the script is running as root ... ok
+Trying to collect system information ... ok
+Trying to disable debug mode for the Docker daemon ... ok
+Trying to restart Docker daemon to enable debug mode ... ok
+Trying to disable debug mode for the Amazon ECS Container Agent ... ok
+Trying to restart the Amazon ECS Container Agent to disable debug mode ... ok
+Trying to restart the Amazon ECS Container Agent to disable debug mode ... ok
 ```
 
 ## Contributing

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -63,7 +63,7 @@ mode='brief' # defined in parse_options
 # ---------------------------------------------------------------------------------------
 
 help() {
-  echo "USAGE: ${progname} [--mode=[brief|enable-debug]]"
+  echo "USAGE: ${progname} [--mode=[brief|enable-debug|disable-debug]]"
   echo "       ${progname} --help"
   echo ""
   echo "OPTIONS:"
@@ -77,6 +77,8 @@ help() {
   echo "     enable-debug  Enables debug mode for the Docker daemon and the Amazon"
   echo "                   ECS Container Agent. Only supported on Systemd init systems"
   echo "                   and Amazon Linux."
+  echo "     disable-debug Disables debug mode for the Docker daemon and the Amazon"
+  echo "                   ECS Container Agent. reverse of enable-debug option."
 }
 
 parse_options() {
@@ -191,6 +193,13 @@ enable_debug() {
   get_init_type
   enable_docker_debug
   enable_ecs_agent_debug
+}
+
+disable_debug() {
+  is_root
+  get_init_type
+  disable_docker_debug
+  disable_ecs_agent_debug
 }
 
 # Routines
@@ -797,6 +806,80 @@ enable_ecs_agent_debug() {
   fi
 }
 
+disable_docker_debug() {
+  try "disable debug mode for the Docker daemon"
+
+  if [ -e /etc/sysconfig/docker ] && ! grep -q "^\\s*OPTIONS=\"-D" /etc/sysconfig/docker; then
+    info "Debug mode is already disabled."
+  else
+
+    if [ -e /etc/sysconfig/docker ]; then
+      case "${init_type}" in
+        systemd)
+          # sed -i 's/^OPTIONS="\(.*\)/OPTIONS="-D \1/g' /etc/sysconfig/docker
+          sed -i 's/\-D//g' /etc/sysconfig/docker
+          ok
+
+          try "restart Docker daemon to enable debug mode"
+          systemctl restart docker.service
+          ok
+          ;;
+        *)
+          # echo "OPTIONS=\"-D \$OPTIONS\"" >> /etc/sysconfig/docker
+          sed -i 's/\-D//g' /etc/sysconfig/docker
+
+          try "restart Docker daemon to enable debug mode"
+          service docker restart
+          ok
+
+        esac
+
+    else
+      warning "the current operating system is not supported."
+    fi
+  fi
+}
+
+disable_ecs_agent_debug() {
+  try "disable debug mode for the Amazon ECS Container Agent"
+
+  if [ -e /etc/ecs/ecs.config ] && ! grep -q "^\\s*ECS_LOGLEVEL=debug" /etc/ecs/ecs.config; then
+    info "Debug mode is already disabled."
+  
+  else
+    case "${init_type}" in
+    systemd)
+      if [ ! -d /etc/ecs ]; then
+        mkdir /etc/ecs
+      fi
+
+      sed -i '/^\s*ECS_LOGLEVEL=debug/d' /etc/ecs/ecs.config
+      ok
+
+      try "restart the Amazon ECS Container Agent to disable debug mode"
+      systemctl restart ecs
+      ok
+      ;;
+    *)
+      if rpm -q --quiet ecs-init; then
+        if [ ! -d /etc/ecs ]; then
+          mkdir /etc/ecs
+        fi
+
+        sed -i '/^\s*ECS_LOGLEVEL=debug/d' /etc/ecs/ecs.config
+        ok
+
+        try "restart the Amazon ECS Container Agent to disable debug mode"
+        stop ecs; start ecs
+        ok
+      else
+        warning "the current operating system is not supported."
+      fi
+      ;;
+    esac
+  fi
+}
+
 # nvidia-smi is a tool available on GPU based AMIs provides detailed
 # information about the GPU present on the VM.
 get_gpu_info() {
@@ -831,6 +914,9 @@ case "${mode}" in
     ;;
   enable-debug)
     enable_debug
+    ;;
+  disable-debug)
+    disable_debug
     ;;
   *)
     help && exit 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Modification for #78 

### Implementation details
Details on #78

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux
- [X] Works properly on Amazon Linux 2
- [X] Works properly on Amazon Linux 2023
- [x] Works partially on Ubuntu 20.04.6 LTS - only ecs agent
- [X] Works partially on CentOS Stream 8 - only ecs agent
- [X] Works partially on Ubuntu 24.04 LTS - only ecs agent

New tests cover the changes: No, Manually tested.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
