### PR TITLE
Remove collecting ecs config  and agent local database files

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -552,19 +552,6 @@ get_ecs_agent_info() {
     fi
   fi
 
-  if [ -e /var/lib/ecs/data/agent.db ]; then
-    cp -f /var/lib/ecs/data/agent.db "$info_system"/ecs-agent/agent.db 2>&1
-    chmod +r "$info_system"/ecs-agent/agent.db
-  fi
-
-  if [ -e /etc/ecs/ecs.config ]; then
-    cp -f /etc/ecs/ecs.config "$info_system"/ecs-agent/ 2>&1
-    if grep --quiet "ECS_ENGINE_AUTH_DATA" "$info_system"/ecs-agent/ecs.config; then
-      sed -i 's/ECS_ENGINE_AUTH_DATA=.*/ECS_ENGINE_AUTH_DATA=/g' "$info_system"/ecs-agent/ecs.config
-    fi
-  fi
-  ok
-
   try "collect Amazon ECS Container Agent engine data"
 
   if pgrep agent > /dev/null ; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will remove collecting the `ecs.config` and `agent.db` files within the log collector script.

### Implementation details
* Removed portions of code within `get_ecs_agent_info` where we're copying over the `ecs.config` and `agent.db` files.

### Testing

Launched an instance using an ECS-Optimized AL2 AMI and executed the log collector script.
```
[ec2-user@ip-172-31-38-176 ~]$ sudo bash log.sh 
Trying to check if the script is running as root ... ok
Trying to resolve instance-id ... getting instance id from ec2 metadata endpoint
ok
Trying to collect system information ... ok
Trying to check disk space usage ... ok
Trying to collect common operating system logs ... ok
Trying to collect kernel logs ... ok
Trying to get mount points and volume information ... ok
Trying to check SELinux status ... ok
Trying to get iptables list ... ok
Trying to detect installed packages ... ok
Trying to detect active system services list ... ok
Trying to gather Docker daemon information ... ok
Trying to inspect all Docker containers ... ok
Trying to collect Docker and containerd daemon logs ... ok
Trying to collect Docker systemd unit file ... ok
Trying to collect containerd systemd unit file ... ok
Trying to collect Docker sysconfig ... ok
Trying to collect Docker storage sysconfig ... ok
Trying to collect Docker daemon.json ... /etc/docker/daemon.json not found
Trying to collect Amazon ECS Container Agent logs ... ok
Trying to collect Amazon ECS Container Agent state and config ... Trying to collect Amazon ECS Container Agent engine data ... ok
Trying to get open files list ... ok
Trying to collect /etc/os-release ... ok
Trying to get uname kernel info ... ok
Trying to get dmidecode info ... ok
Trying to get lsmod info ... ok
Trying to collect systemd slice info ... ok
Trying to get veth info ... ok
Trying to get gpu info ... log.sh: line 817: ./collect/i-00f13d437fbcfaa3b/gpu/gpu-installed-kmod.txt: No such file or directory
ok
Trying to archive gathered log information ... ok
```

Confirmed that both `ecs.config` and `agent.db` is no longer present in the list of files being collected
```
[ec2-user@ip-172-31-38-176 i-00f13d437fbcfaa3b]$ pwd
/home/ec2-user/collect/i-00f13d437fbcfaa3b
[ec2-user@ip-172-31-38-176 i-00f13d437fbcfaa3b]$ ls ecs-agent/
agent-running-info.txt
[ec2-user@ip-172-31-38-176 i-00f13d437fbcfaa3b]$ ls ecs_agent_logs/
ecs-agent.log  ecs-init.log  ecs-volume-plugin.log  exec
[ec2-user@ip-172-31-38-176 i-00f13d437fbcfaa3b]$ ls
containerd.log  docker_log  ecs_agent_logs   ipaddrshow.txt       iptables-nat.txt  lsmod.txt   netstat.txt           open-file-details.txt  pkglist.txt  selinux.txt   system.log    top.txt    var_log
docker          ecs-agent   instance-id.txt  iptables-filter.txt  kernel            mounts.txt  open-file-counts.txt  os-release             ps.txt       services.txt  system.slice  uname.txt
```

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
