### PR TITLE
remove docker containers info

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -581,6 +581,11 @@ get_docker_containers_info() {
 
   if pgrep dockerd > /dev/null ; then
     for i in $(docker ps -a -q); do
+      container_name=$(docker inspect --format '{{ index . "Name" }}' "$i")
+      if [ "$container_name" != "/ecs-agent" ]; then
+        continue
+      fi
+
       timeout 10 docker inspect "$i" > "$info_system"/docker/container-"$i".txt 2>&1
       if [ $? -eq 124 ]; then
         touch "$info_system"/docker/container-inspect-timed-out.txt


### PR DESCRIPTION
### Summary
This change removes docker inspect information collection for containers under the collect/i-###/docker directory for every container except ecs-agent.

### Implementation details
We skip if the docker inspect collection if the container's name is not /ecs-agent

### Testing
Launched a container-instance and verified that the docker inspect info is only collected for agent when using the halit-test branch of the ecs-logs-collector

```
[ec2-user@ip-172-31-8-25 ~]$ curl -O https://raw.githubusercontent.com/aws/amazon-ecs-logs-collector/halit-test/ecs-logs-collector.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20906  100 20906    0     0   136k      0 --:--:-- --:--:-- --:--:--  137k
[ec2-user@ip-172-31-8-25 ~]$ ls
ecs-logs-collector.sh
[ec2-user@ip-172-31-8-25 ~]$ sudo bash ecs-logs-collector.sh 
Trying to check if the script is running as root ... ok
Trying to resolve instance-id ... getting instance id from ec2 metadata endpoint
ok
Trying to collect system information ... ok
Trying to check disk space usage ... ok
Trying to collect common operating system logs ... ok
Trying to collect kernel logs ... ok
Trying to get mount points and volume information ... ok
Trying to check SELinux status ... ok
Trying to get iptables list ... ok
Trying to detect installed packages ... ok
Trying to detect active system services list ... ok
Trying to gather Docker daemon information ... ok
Trying to inspect all Docker containers ... ok
Trying to collect Docker and containerd daemon logs ... ok
Trying to collect Docker systemd unit file ... ok
Trying to collect containerd systemd unit file ... ok
Trying to collect Docker sysconfig ... ok
Trying to collect Docker storage sysconfig ... ok
Trying to collect Docker daemon.json ... /etc/docker/daemon.json not found
Trying to collect Amazon ECS Container Agent logs ... ok
Trying to collect Amazon ECS Container Agent state and config ... Trying to collect Amazon ECS Container Agent engine data ... ok
Trying to get open files list ... ok
Trying to collect /etc/os-release ... ok
Trying to get uname kernel info ... ok
Trying to get dmidecode info ... ok
Trying to get lsmod info ... ok
Trying to collect systemd slice info ... ok
Trying to get veth info ... ok
Trying to get gpu info ... ecs-logs-collector.sh: line 809: ./collect/i-0a1ceaa8b94e035ee/gpu/gpu-installed-kmod.txt: No such file or directory
ok
Trying to archive gathered log information ... ok
```
Confirmed that the info is not collected for the other container:
```
[ec2-user@ip-172-31-8-25 ~]$ cd collect
[ec2-user@ip-172-31-8-25 collect]$ cd i-0a1ceaa8b94e035ee/
[ec2-user@ip-172-31-8-25 i-0a1ceaa8b94e035ee]$ cd docker
[ec2-user@ip-172-31-8-25 docker]$ ls
container-7193a1a8563a.txt  docker-images.txt  docker-ps.txt   docker-stats.txt    sysconfig-docker
containerd.service          docker-info.txt    docker.service  docker-version.txt  sysconfig-docker-storage
```

```
[ec2-user@ip-172-31-8-25 docker]$ cat container-7193a1a8563a.txt | jq -r '.[0].Name'
/ecs-agent
```


As compared to before changes:
```
[ec2-user@ip-172-31-8-25 collect]$ cd i-0a1ceaa8b94e035ee/
[ec2-user@ip-172-31-8-25 i-0a1ceaa8b94e035ee]$ cd docker
[ec2-user@ip-172-31-8-25 docker]$ ls
container-7193a1a8563a.txt  container-e1bb89c85b53.txt  docker-info.txt  docker.service    docker-version.txt  sysconfig-docker-storage
containerd.service          docker-images.txt           docker-ps.txt    docker-stats.txt  sysconfig-docker
```

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
