### PR TITLE
ecs.config and container information logging 

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -552,6 +552,17 @@ get_ecs_agent_info() {
     fi
   fi
 
+  if [ -e /etc/ecs/ecs.config ]; then
+    cp -f /etc/ecs/ecs.config "$info_system"/ecs-agent/ 2>&1
+    keys_to_remove=("ECS_ENGINE_AUTH_DATA" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY" "AWS_SESSION_TOKEN")
+    for key in "${keys_to_remove[@]}"; do
+      if grep --quiet "${key}" "$info_system"/ecs-agent/ecs.config; then
+        sed -i "s/${key}=.*/${key}=/g" "$info_system"/ecs-agent/ecs.config
+      fi
+    done
+  fi
+  ok
+
   try "collect Amazon ECS Container Agent engine data"
 
   if pgrep agent > /dev/null ; then

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -62,6 +62,39 @@ mode='brief' # defined in parse_options
 
 vars_to_redact=("ECS_ENGINE_AUTH_DATA" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY" "AWS_SESSION_TOKEN")
 
+declare -A ecs_config_allowlist
+ecs_config_allowlist=(
+    ["ECS_CLUSTER"]=1                            ["ECS_RESERVED_PORTS"]=1                           ["ECS_RESERVED_PORTS_UDP"]=1
+    ["ECS_ENGINE_AUTH_TYPE"]=1                   ["AWS_DEFAULT_REGION"]=1                           ["DOCKER_HOST"]=1
+    ["ECS_LOGLEVEL"]=1                           ["ECS_LOGLEVEL_ON_INSTANCE"]=1                     ["ECS_LOGFILE"]=1
+    ["ECS_CHECKPOINT"]=1                         ["ECS_DATADIR"]=1                                  ["ECS_UPDATES_ENABLED"]=1
+    ["ECS_DISABLE_METRICS"]=1                    ["ECS_POLL_METRICS"]=1                             ["ECS_POLLING_METRICS_WAIT_DURATION"]=1
+    ["ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT"]=1  ["ECS_RESERVED_MEMORY"]=1                          ["ECS_AVAILABLE_LOGGING_DRIVERS"]=1
+    ["ECS_DISABLE_PRIVILEGED"]=1                 ["ECS_SELINUX_CAPABLE"]=1                          ["ECS_APPARMOR_CAPABLE"]=1
+    ["ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION"]=1  ["ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER"]=1 ["ECS_MANIFEST_PULL_TIMEOUT"]=1
+    ["ECS_CONTAINER_STOP_TIMEOUT"]=1             ["ECS_CONTAINER_START_TIMEOUT"]=1                  ["ECS_CONTAINER_CREATE_TIMEOUT"]=1
+    ["ECS_ENABLE_TASK_IAM_ROLE"]=1               ["ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"]=1        ["ECS_DISABLE_IMAGE_CLEANUP"]=1
+    ["ECS_IMAGE_CLEANUP_INTERVAL"]=1             ["ECS_IMAGE_MINIMUM_CLEANUP_AGE"]=1                ["NON_ECS_IMAGE_MINIMUM_CLEANUP_AGE"]=1
+    ["ECS_NUM_IMAGES_DELETE_PER_CYCLE"]=1        ["ECS_IMAGE_PULL_BEHAVIOR"]=1                      ["ECS_IMAGE_PULL_INACTIVITY_TIMEOUT"]=1
+    ["ECS_IMAGE_PULL_TIMEOUT"]=1                 ["ECS_INSTANCE_ATTRIBUTES"]=1                      ["ECS_ENABLE_TASK_ENI"]=1
+    ["ECS_ENABLE_HIGH_DENSITY_ENI"]=1            ["ECS_CNI_PLUGINS_PATH"]=1                         ["ECS_AWSVPC_BLOCK_IMDS"]=1
+    ["ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES"]=1     ["ECS_ENABLE_CONTAINER_METADATA"]=1                ["ECS_HOST_DATA_DIR"]=1
+    ["ECS_ENABLE_TASK_CPU_MEM_LIMIT"]=1          ["ECS_CGROUP_PATH"]=1                              ["ECS_CGROUP_CPU_PERIOD"]=1
+    ["ECS_AGENT_HEALTHCHECK_HOST"]=1             ["ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND"]=1  ["ECS_ENABLE_MEMORY_UNBOUNDED_WINDOWS_WORKAROUND"]=1
+    ["ECS_TASK_METADATA_RPS_LIMIT"]=1            ["ECS_SHARED_VOLUME_MATCH_FULL_CONFIG"]=1          ["ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM"]=1
+    ["ECS_CONTAINER_INSTANCE_TAGS"]=1            ["ECS_ENABLE_UNTRACKED_IMAGE_CLEANUP"]=1           ["ECS_EXCLUDE_UNTRACKED_IMAGE"]=1
+    ["ECS_DISABLE_DOCKER_HEALTH_CHECK"]=1        ["ECS_NVIDIA_RUNTIME"]=1                           ["ECS_ALTERNATE_CREDENTIAL_PROFILE"]=1
+    ["ECS_ENABLE_SPOT_INSTANCE_DRAINING"]=1      ["ECS_LOG_ROLLOVER_TYPE"]=1                        ["ECS_LOG_OUTPUT_FORMAT"]=1
+    ["ECS_LOG_MAX_FILE_SIZE_MB"]=1               ["ECS_LOG_MAX_ROLL_COUNT"]=1                       ["ECS_LOG_DRIVER"]=1
+    ["ECS_LOG_OPTS"]=1                           ["ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE"]=1    ["ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED"]=1
+    ["ECS_ENABLE_RUNTIME_STATS"]=1               ["ECS_EXCLUDE_IPV6_PORTBINDING"]=1                 ["ECS_WARM_POOLS_CHECK"]=1
+    ["ECS_SKIP_LOCALHOST_TRAFFIC_FILTER"]=1      ["ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS"]=1       ["ECS_OFFHOST_INTROSPECTION_INTERFACE_NAME"]=1
+    ["ECS_ENABLE_GPU_SUPPORT"]=1                 ["HTTP_PROXY"]=1                                   ["NO_PROXY"]=1
+    ["ECS_GMSA_SUPPORTED"]=1                     ["CREDENTIALS_FETCHER_HOST"]=1                     ["CREDENTIALS_FETCHER_SECRET_NAME_FOR_DOMAINLESS_GMSA"]=1
+    ["ECS_DYNAMIC_HOST_PORT_RANGE"]=1            ["ECS_TASK_PIDS_LIMIT"]=1                          ["ECS_EBSTA_SUPPORTED"]=1
+    ["ECS_SKIP_LOCALHOST_TRAFFIC_FILTER"]=1      ["ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS"]=1       ["ECS_OFFHOST_INTROSPECTION_INTERFACE_NAME"]=1
+    ["ECS_AGENT_LABELS"]=1                       ["ECS_AGENT_APPARMOR_PROFILE"]=1
+)
 
 # Common functions
 # ---------------------------------------------------------------------------------------
@@ -569,12 +602,24 @@ get_ecs_agent_info() {
   fi
 
   if [ -e /etc/ecs/ecs.config ]; then
-    cp -f /etc/ecs/ecs.config "$info_system"/ecs-agent/ 2>&1
-    for var in "${vars_to_redact[@]}"; do
-      if grep --quiet "${var}" "$info_system"/ecs-agent/ecs.config; then
-        sed -i "s/${var}=.*/${var}={REDACTED}/g" "$info_system"/ecs-agent/ecs.config
+    source_file="/etc/ecs/ecs.config"
+
+    line_is_safe=0
+    while IFS= read -r line; do
+      if [[ "$line" == *"="* ]]; then
+        var_name="${line%%=*}"
+        if [[ -v ecs_config_allowlist["$var_name"] ]]; then
+          line_is_safe=1
+        else
+          line_is_safe=0
+          echo "$var_name={REDACTED}" >> "$info_system"/ecs-agent/ecs.config
+        fi
       fi
-    done
+
+      if [[ $line_is_safe -eq 1 ]]; then 
+        echo "$line" >> "$info_system"/ecs-agent/ecs.config
+      fi
+    done < "$source_file"
   fi
   ok
 


### PR DESCRIPTION
### Summary
Reintroduce logging of container information and ecs.config file contents, as well as additional processing of ecs_agent_logs files. 

### Implementation details
ecs.config logging: 
Collects ecs.config into the logs. Only includes known ecs.config variables that are not sensitive. 

container logging:
Collects container info with docker inspect. Hides all environment variables in the container as the environment variable values may contain secrets. 

### Testing

#### ecs.config logging example output based on input: 

Input ecs.config:
```
ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES=["10.0.15.0/24"]
AWS_ACCESS_KEY_ID=another_secret
RANDOM_VAR=this should not remain
AWS_SECRET_ACCESS_KEY=another_secret_1
AWS_SESSION_TOKEN=another_secret_2
ECS_ENGINE_AUTH_DATA=something_secret
UNKNOWN_VAR="""
Assume that this is a random key, this should not remain at all
"""
ECS_ENABLE_CONTAINER_METADATA=this_should_remain_as_well
ECS_CONTAINER_INSTANCE_TAGS="""
{
"tag_key": "tag_val",
"another_tag_key": "another_tag_val_for_multi_line_testing"
}
"""
ANOTHER_UNKNOWN=also remove this
```

Output in logs: 
```
ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES=["10.0.15.0/24"]
AWS_ACCESS_KEY_ID={REDACTED}
RANDOM_VAR={REDACTED}
AWS_SECRET_ACCESS_KEY={REDACTED}
AWS_SESSION_TOKEN={REDACTED}
ECS_ENGINE_AUTH_DATA={REDACTED}
UNKNOWN_VAR={REDACTED}
ECS_ENABLE_CONTAINER_METADATA=this_should_remain_as_well
ECS_CONTAINER_INSTANCE_TAGS="""
{
"tag_key": "tag_val",
"another_tag_key": "another_tag_val_for_multi_line_testing"
}
"""
ANOTHER_UNKNOWN={REDACTED}
```

#### container logging example output: 

```
        ...,
        "Env": [
                "ECS_EBSTA_SUPPORTED={REDACTED}"
                "ECS_AGENT_CONFIG_FILE_PATH={REDACTED}"
                "ECS_ENABLE_TASK_IAM_ROLE={REDACTED}"
                "CREDENTIALS_FETCHER_HOST_DIR={REDACTED}"
                "ECS_ENABLE_TASK_ENI={REDACTED}"
                "ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE={REDACTED}"
                "ECS_VOLUME_PLUGIN_CAPABILITIES={REDACTED}"
                "ECS_AVAILABLE_LOGGING_DRIVERS={REDACTED}"
                "ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST={REDACTED}"
                "ECS_AGENT_LABELS={REDACTED}"
                "ECS_UPDATE_DOWNLOAD_DIR={REDACTED}"
                "SSL_CERT_DIR={REDACTED}"
                "ECS_DATADIR={REDACTED}"
                "ECS_UPDATES_ENABLED={REDACTED}"
                "ECS_LOGFILE={REDACTED}"
                "PATH={REDACTED}"
        ],
        ...
```

#### ecs agent logs test file input and processed output:

`logs-collector-sanitization-test.log` was added under `ecs_agent_logs`:

```
level=info time=2024-08-01T17:03:24Z msg="ECS_ENGINE_AUTH_DATA=something_something this is a test"
level=info time=2024-08-01T17:03:24Z msg="Reconnecting to ACS immediately AWS_ACCESS_KEY_ID=another secret"
level=info time=2024-08-01T17:03:24Z msg="Using cached DiscoverPollEndpoint AWS_SESSION_TOKEN=hide this as well" telemetryEndpoint="https://ecs-t-6.us-west-2.amazonaws.com/" serviceConnectEndpoint="https://ecs-sc.us-west-2.api.aws" containerInstanceARN="arn:aws:ecs:us-west-2:543318069049:container-instance/default/52b49a6c2e724ad4b00ea7ac1d3cfb43" endpoint="https://ecs-a-6.us-west-2.amazonaws.com/"
level=error time=2024-08-01T17:03:24Z msg="AWS_SECRET_ACCESS_KEY=this should be deleted" "interesting"
level=info time=2024-08-01T17:03:24Z msg="AWS_SECRET_ACCESS_KEY didn't work! (this is a test message that should be kept" 
```

The following is the processed output in the logs collector

```
level=info time=2024-08-01T17:03:24Z msg="ECS_ENGINE_AUTH_DATA={REDACTED}"
level=info time=2024-08-01T17:03:24Z msg="Reconnecting to ACS immediately AWS_ACCESS_KEY_ID={REDACTED}"
level=info time=2024-08-01T17:03:24Z msg="Using cached DiscoverPollEndpoint AWS_SESSION_TOKEN={REDACTED}"
level=error time=2024-08-01T17:03:24Z msg="AWS_SECRET_ACCESS_KEY={REDACTED}"
level=info time=2024-08-01T17:03:24Z msg="AWS_SECRET_ACCESS_KEY didn't work! (this is a test message that should be
kept"
```

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
