### PR TITLE
Fix for all ecs.config variables being redacted in AL2

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -608,7 +608,7 @@ get_ecs_agent_info() {
     while IFS= read -r line; do
       if [[ "$line" == *"="* ]]; then
         var_name="${line%%=*}"
-        if [[ -v ecs_config_allowlist["$var_name"] ]]; then
+        if [[ -n "${ecs_config_allowlist[$var_name]+x}" ]]; then
           line_is_safe=1
         else
           line_is_safe=0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

For AL2 AMIs, when running the log collector script, all ECS agent environment variables are redacted

```
[root@ip amazon-ecs-logs-collector]# cat collect/i-xxxxxxxxxxxx/ecs-agent/ecs.config
ECS_CLUSTER={REDACTED}
AWS_DEFAULT_REGION={REDACTED}
ECS_ENGINE_AUTH_DATA={REDACTED}
ECS_DISABLE_IMAGE_CLEANUP={REDACTED}
```

[root@ip ~]# /usr/bin/env bash --version
GNU bash, version 4.2.46(2)-release (x86_64-koji-linux-gnu)

### Implementation details

This is due to AL2 still using bash v4, which doesn't handle ` if [[ -v ecs_config_allowlist["$var_name"]` correctly. Switching the `if` to the -n operator (test for non empty string returned from var test) will be compatible for bash v4 and v5

### Testing
<!-- How was this tested? -->
- [ X ] Works properly on Amazon Linux 2 (bash 4)
- [ X ] Works properly on Amazon Linux 2023 (bash 5)
- [ X ] Works properly on Ubuntu 22 (bash 5)
- [ X ] Works properly on RHEL 8 (bash 5)

New tests cover the changes: <!-- yes|no -->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
