### PR TITLE
Add SSM Agent logs

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -221,6 +221,7 @@ collect_brief() {
   get_systemd_slice_info
   get_veth_info
   get_gpu_info
+  get_ssm_logs
 }
 
 enable_debug() {
@@ -543,6 +544,23 @@ get_pkglist() {
       ;;
   esac
 
+  ok
+}
+
+get_ssm_logs() {
+  try "collect SSM agent logs"
+
+  dstdir="${info_system}/ssm_agent_logs"
+  mkdir -p "$dstdir"
+
+  if command -v journalctl >/dev/null; then
+    journalctl -u amazon-ssm-agent > "$dstdir"/journalctl.log
+  fi
+
+  if [ -d /var/log/amazon/ssm ]; then
+    cp -f -r /var/log/amazon/ssm/* "$dstdir"/
+  fi
+  
   ok
 }
 

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -548,18 +548,27 @@ get_pkglist() {
 }
 
 get_ssm_logs() {
-  try "collect SSM agent logs"
+  try "collect Amazon SSM Agent logs"
 
   dstdir="${info_system}/ssm_agent_logs"
   mkdir -p "$dstdir"
 
   if command -v journalctl >/dev/null; then
-    journalctl -u amazon-ssm-agent > "$dstdir"/journalctl.log
+    systemctl status amazon-ssm-agent >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      journalctl -u amazon-ssm-agent > "$dstdir"/journalctl.log
+    elif command -v snap >/dev/null; then
+      systemctl status snap.amazon-ssm-agent.amazon-ssm-agent.service >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        snap logs amazon-ssm-agent > "$dstdir"/snap-services.log
+      else
+        warning "Amazon SSM Agent is not running."
+      fi
+    else
+      warning "Amazon SSM Agent is not running."
+    fi
   fi
 
-  if command -v snap >/dev/null; then
-    snap logs amazon-ssm-agent > "$dstdir"/snap.log
-  fi
 
   if [ -d /var/log/amazon/ssm ]; then
     cp -f -r /var/log/amazon/ssm/* "$dstdir"/

--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -557,8 +557,14 @@ get_ssm_logs() {
     journalctl -u amazon-ssm-agent > "$dstdir"/journalctl.log
   fi
 
+  if command -v snap >/dev/null; then
+    snap logs amazon-ssm-agent > "$dstdir"/snap.log
+  fi
+
   if [ -d /var/log/amazon/ssm ]; then
     cp -f -r /var/log/amazon/ssm/* "$dstdir"/
+  else
+    warning "SSM log directory does not exist."
   fi
   
   ok


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

Capturing SSM agent logs.  
It is requested in the issue https://github.com/aws/amazon-ecs-logs-collector/issues/84

### Implementation details
<!-- How are the changes implemented? -->

Adding `get_ssm_logs` function.
This function collects SSM agent logs with the following commands.

- journalctl -u amazon-ssm-agent
- snap logs amazon-ssm-agent (For Ubuntu)
- cp -f -r /var/log/amazon/ssm/*

https://github.com/Mic-U/amazon-ecs-logs-collector/blob/issues/84/ecs-logs-collector.sh#L550-L580

### Testing
<!-- How was this tested? -->
- [x] Works properly on Amazon Linux 2
- [x] Works properly on Amazon Linux 2023
- [ ] Works properly on Ubuntu 20.04
- [ ] Works properly on CentOS 8

Ubuntu 20.04 is becoming EOL soon.  
https://ubuntu.com/about/release-cycle

CentOS 8 has already been EOL.
https://www.centos.org/centos-linux-eol/

So, I tested with Ubuntu 22.04 and CentOS9, it looks working fine.

New tests cover the changes: No, tested manually

### Licensing

This contribution is under the terms of the Apache 2.0 License:  Yes
