### PR TITLE
Collect nv-hostengine logs

### DIFF
--- a/ecs-logs-collector.sh
+++ b/ecs-logs-collector.sh
@@ -890,6 +890,10 @@ get_gpu_info() {
     modinfo nvidia > "$info_system"/gpu/gpu-installed-kmod.txt
   fi
 
+  if [ -e /var/log/nv-hostengine.log ]; then
+    cp -f /var/log/nv-hostengine.log "$info_system"/gpu/
+  fi
+
   ok
 }
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/awslabs/ecs-logs-collector/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Collect nv-hostengine logs located in: `/var/log/nv-hostengine.log`. Suggested in a PR comment here: https://github.com/aws/amazon-ecs-ami/pull/747#discussion_r3625062945

Sample logs from `/var/log/nv-hostengine.log`: 
```
2026-07-21 05:19:17.922 ERROR [8999:8999] [[NvSwitch]] Could not load NVSDM [./modules/nvswitch/DcgmNvsdmManager.cpp:974] [DcgmNs::DcgmNvsdmManager::AttachToNvsdm]
2026-07-21 05:19:17.922 ERROR [8999:8999] [[NvSwitch]] AttachToNvsdm() returned -25 [./modules/nvswitch/DcgmNvsdmManager.cpp:940] [DcgmNs::DcgmNvsdmManager::Init]
2026-07-21 05:19:17.922 ERROR [8999:8999] [[NvSwitch]] Could not load NSCQ. dlwrap_attach ret: Can not access a needed shared library (-79): If this system has NvSwitches, please ensure that the package libnvidia-nscq is installed on your system and that the service user has permissions to access it. [./modules/nvswitch/DcgmNscqManager.cpp:503] [DcgmNs::DcgmNscqManager::AttachToNscq]
2026-07-21 05:19:17.922 ERROR [8999:8999] [[NvSwitch]] AttachToNscq() returned -25 [./modules/nvswitch/DcgmNscqManager.cpp:339] [DcgmNs::DcgmNscqManager::Init]
2026-07-21 05:19:17.923 ERROR [8999:9058] [[NvSwitch]] Status changed to disconnected: Not attached to driver, aborting [./modules/nvswitch/DcgmNvSwitchManagerBase.cpp:572] [DcgmNs::DcgmNvSwitchManagerBase::CheckAndLogConnectionStatus]
2026-07-21 05:20:18.415 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:20:18.415 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:21:18.253 ERROR [8999:9025] [[Health]] Detected a WARNING in health system Power: 'Detected clocks event due to power violation in GPU 0. Monitor the power conditions. This GPU can still perform workload.' [./modules/health/DcgmHealthWatch.cpp:890] [DcgmHealthWatch::SetResponse]
2026-07-21 05:21:18.416 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:21:18.416 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:22:18.418 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:22:18.418 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:23:17.963 ERROR [8999:9024] [[Health]] Detected a WARNING in health system Power: 'Detected clocks event due to power violation in GPU 0. Monitor the power conditions. This GPU can still perform workload.' [./modules/health/DcgmHealthWatch.cpp:890] [DcgmHealthWatch::SetResponse]
2026-07-21 05:23:18.420 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:23:18.420 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:24:18.014 ERROR [8999:9025] [[Health]] Detected a WARNING in health system Power: 'Detected clocks event due to power violation in GPU 0. Monitor the power conditions. This GPU can still perform workload.' [./modules/health/DcgmHealthWatch.cpp:890] [DcgmHealthWatch::SetResponse]
2026-07-21 05:24:18.422 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:24:18.422 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
2026-07-21 05:25:17.983 ERROR [8999:9024] [[Health]] Detected a WARNING in health system Power: 'Detected clocks event due to power violation in GPU 0. Monitor the power conditions. This GPU can still perform workload.' [./modules/health/DcgmHealthWatch.cpp:890] [DcgmHealthWatch::SetResponse]
2026-07-21 05:25:18.425 ERROR [8999:9059] Couldn't find the nvidia-imex-ctl binary in the predefined search paths (/usr/bin:/usr/local/bin:/opt/nvidia/imex/bin:/usr/local/nvidia/imex/bin:/usr/libexec/datacenter-gpu-manager-4) [./common/DcgmUtilities.cpp:1340] [DcgmNs::Utils::FindExecutable]
```

### Implementation details
<!-- How are the changes implemented? -->

Modified shell script. 

### Testing
<!-- How was this tested? -->
- [ ✅ ] Works properly on Amazon Linux 2
- [ ✅ ] Works properly on Amazon Linux 2023
- [  ] Works properly on Ubuntu 20.04 (EOL: https://ubuntu.com/about/release-cycle, **tested on Ubuntu 20.04, 22.04, 24.04, 26.04 instead and confirmed it works**)
- [  ] Works properly on CentOS 8 (EOL: https://www.centos.org/centos-linux-eol/, **tested on CentOS 9 instead and confirmed it works**)

Confirmed via creating custom AMI and checking that nv-hostengine logs exist in `/var/log/nv-hostengine.log` and ran `cat /var/log/nv-hostengine.log | head -n 20` to get the above output. 

New tests cover the changes: <!-- yes|no --> yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
 yes